### PR TITLE
Improvements and debugging for evaluate

### DIFF
--- a/treesapp/annotate_extra.py
+++ b/treesapp/annotate_extra.py
@@ -19,6 +19,8 @@ def check_arguments(layerer: Layerer, args):
     :return:
     """
     layerer.treesapp_output = args.output
+    if layerer.treesapp_output[-1] != os.sep:
+        layerer.treesapp_output += os.sep
     layerer.var_output_dir = layerer.treesapp_output + "intermediates" + os.sep
     layerer.final_output_dir = layerer.treesapp_output + "final_outputs" + os.sep
     if not os.path.isfile(layerer.final_output_dir + "marker_contig_map.tsv"):

--- a/treesapp/clade_exclusion_evaluator.py
+++ b/treesapp/clade_exclusion_evaluator.py
@@ -306,7 +306,7 @@ def map_headers_to_lineage(assignments, ref_sequences):
                         break
                 if not mapped:
                     logging.warning("Unable to map classified sequence '" + query + "' to a lineage.\n")
-                    sys.exit()
+                    sys.exit(3)
             if len(lineage_assignments[marker][c_lineage]) > len(classified_headers):
                 logging.error(str(len(classified_headers)) + " accessions mapped to " +
                               str(len(lineage_assignments[marker][c_lineage])) + " lineages.\n")
@@ -314,6 +314,7 @@ def map_headers_to_lineage(assignments, ref_sequences):
             elif len(lineage_assignments[marker][c_lineage]) < len(classified_headers):
                 logging.debug(str(len(classified_headers)) + " accessions mapped to " +
                               str(len(lineage_assignments[marker][c_lineage])) + " lineages.\n")
+        print(lineage_assignments[marker])
     return lineage_assignments
 
 
@@ -346,8 +347,10 @@ def pick_taxonomic_representatives(ref_seqs_list, taxonomic_filter_stats, max_cl
     dereplicated_lineages = dict()
     num_rep_seqs = 0
     for ref_seq in ref_seqs_list:
+        print(ref_seq.lineage)
         query_taxonomy = clean_lineage_string(ref_seq.lineage)
-        if len(clean_lineage_string(query_taxonomy).split("; ")) < 7:
+        if len(query_taxonomy.split("; ")) < 7:
+            print("Skipping", query_taxonomy)
             continue
         if query_taxonomy not in good_classified_lineages:
             good_classified_lineages[query_taxonomy] = list()
@@ -393,7 +396,7 @@ def pick_taxonomic_representatives(ref_seqs_list, taxonomic_filter_stats, max_cl
 
     taxonomic_filter_stats["Unique_taxa"] += len(dereplicated_lineages)
 
-    logging.info("\t" + str(num_rep_seqs) + " representative sequences will be used for TreeSAPP analysis.\n")
+    logging.info("\t" + str(num_rep_seqs) + " representative sequences will be used for TreeSAPP evaluate analysis.\n")
 
     logging.debug("Representative sequence stats:\n\t" +
                   "Maximum representative sequences for a taxon " + str(taxonomic_filter_stats["Max"]) + "\n\t" +

--- a/treesapp/commands.py
+++ b/treesapp/commands.py
@@ -932,7 +932,7 @@ def evaluate(sys_args):
                 ref_seqs.fasta_dict[seq_id] = ref_seqs.fasta_dict[seq_id][random_start:random_start + args.length]
     ref_seqs.header_registry = register_headers(get_headers(ref_seqs.file))
 
-    fasta_records = ts_evaluate.fetch_entrez_lineages(ref_seqs, args.molecule, args.acc_to_taxid).values()
+    fasta_records = ts_evaluate.fetch_entrez_lineages(ref_seqs, args.molecule, args.acc_to_taxid)
     create_refpkg.fill_ref_seq_lineages(fasta_records, ts_evaluate.seq_lineage_map)
 
     logging.info("Selecting representative sequences for each taxon.\n")

--- a/treesapp/commands.py
+++ b/treesapp/commands.py
@@ -933,6 +933,7 @@ def evaluate(sys_args):
     ref_seqs.header_registry = register_headers(get_headers(ref_seqs.file))
 
     fasta_records = ts_evaluate.fetch_entrez_lineages(ref_seqs, args.molecule, args.acc_to_taxid).values()
+    create_refpkg.fill_ref_seq_lineages(fasta_records, ts_evaluate.seq_lineage_map)
 
     logging.info("Selecting representative sequences for each taxon.\n")
 

--- a/treesapp/fasta.py
+++ b/treesapp/fasta.py
@@ -491,6 +491,9 @@ def get_headers(fasta_file):
         original_headers.append('>' + str(name))
 
     fasta.close()
+    if len(original_headers) == 0:
+        logging.error("No sequence headers read from FASTA file " + fasta_file + "\n")
+        sys.exit(3)
     logging.debug("Read " + str(n_headers) + " headers from " + fasta_file + ".\n")
 
     return original_headers

--- a/treesapp/lca_calculations.py
+++ b/treesapp/lca_calculations.py
@@ -115,9 +115,9 @@ def identify_excluded_clade(assignment_dict, trie, marker):
 
     for ref_lineage in assignment_dict[marker]:
         log_stats += "Assigned reference lineage: " + ref_lineage + "\n"
-        for query_lineage in assignment_dict[marker][ref_lineage]:
-            if not re.search(r"^Root; ", query_lineage):
-                query_lineage = "Root; " + query_lineage
+        for query_lineage in assignment_dict[marker][ref_lineage]:  # type: str
+            if query_lineage.split('; ')[0] != "Root":
+                query_lineage = "; ".join(["Root"] + query_lineage.split("; "))
             # if query_lineage == ref_lineage:
             #     logging.debug("\tQuery lineage: " + query_lineage + ", " +
             #                   "Optimal lineage: " + ref_lineage + "\n")

--- a/treesapp/treesapp_args.py
+++ b/treesapp/treesapp_args.py
@@ -371,9 +371,6 @@ def check_evaluate_arguments(evaluator_instance: Evaluator, args, marker_build_d
     if args.acc_to_lin:
         evaluator_instance.acc_to_lin = args.acc_to_lin
         if os.path.isfile(evaluator_instance.acc_to_lin):
-            logging.info("Reading cached lineages in '" + evaluator_instance.acc_to_lin + "'... ")
-            evaluator_instance.seq_lineage_map.update(read_accession_taxa_map(evaluator_instance.acc_to_lin))
-            logging.info("done.\n")
             evaluator_instance.change_stage_status("lineages", False)
         else:
             logging.error("Unable to find accession-lineage mapping file '" + evaluator_instance.acc_to_lin + "'\n")


### PR DESCRIPTION
Modified the classification performance table to include the number of over- and under-predictions for each rank's taxonomic distance. This can be used to tune the phylogenetic distance-taxonomic rank model, beyond being used for characterizing the sorts of mistakes it makes for a given reference package.

Debugging involved updating the functions to fit with the usual workflow for downloading and/or mapping accessions to NCBI taxonomic IDs and lineages. Minor adjustments were required.