### PR TITLE
Purity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,22 @@ though, as in the previous assign command, we recommend using the `--trim_align`
 
 ## Tutorials
 
-The easiest way to get started with TreeSAPP is by using [Terraform](https://github.com/hallamlab/TreeSAPP/tree/master/terraform)
- to provision a Google Cloud Platform instance with TreeSAPP and all its dependencies. __OUTDATED__
-
 If we do not yet have a reference package for a gene you are interested in,
 please try [building a new reference package](https://github.com/hallamlab/TreeSAPP/blob/master/docs/Marker_package_creation_tutorial.md).
 Of course, if you run into any problems or would like to collaborate on building many reference packages
 don't hesitate to email us or create a new issue with an 'enhancement' label.
 
+To determine whether the sequences used to build your new reference package are what you think they are,
+ and whether it might unexpectedly annotate homologous sequences,
+ see the [purity tutorial](https://github.com/hallamlab/TreeSAPP/blob/master/docs/purity_tutorial.md).
+
 If you are working with a particularly complex reference package, from an orthologous group for example, or have extra
  phylogenetic information you'd like to include in your classifications,
  try [annotating extra features](https://github.com/hallamlab/TreeSAPP/blob/master/docs/layering_tutorial.md) with `treesapp layer`.
 
+The easiest way to get started with TreeSAPP is by using [Terraform](https://github.com/hallamlab/TreeSAPP/tree/master/terraform)
+ to provision a Google Cloud Platform instance with TreeSAPP and all its dependencies.
+ __This is outdated and scripts supporting this are under repair__
 
 Yet to come:
 - [Evaluating classification accuracy]()

--- a/dev_utils/TIGRFAM_info.tsv
+++ b/dev_utils/TIGRFAM_info.tsv
@@ -1,0 +1,4488 @@
+rpmI_bact	TIGR00001	ribosomal protein bL35
+S16	TIGR00002	ribosomal protein bS16
+TIGR00003	TIGR00003	copper ion binding protein
+TIGR00004	TIGR00004	reactive intermediate/imine deaminase
+rluA_subfam	TIGR00005	pseudouridine synthase, RluA family
+TIGR00006	TIGR00006	16S rRNA (cytosine(1402)-N(4))-methyltransferase
+TIGR00007	TIGR00007	1-(5-phosphoribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide isomerase
+infA	TIGR00008	translation initiation factor IF-1
+L28	TIGR00009	ribosomal protein bL28
+TIGR00010	TIGR00010	hydrolase, TatD family
+YbaK_EbsC	TIGR00011	Cys-tRNA(Pro) deacylase
+L29	TIGR00012	ribosomal protein uL29
+taut	TIGR00013	4-oxalocrotonate tautomerase family enzyme
+arsC	TIGR00014	arsenate reductase (glutaredoxin)
+ackA	TIGR00016	acetate kinase
+cmk	TIGR00017	cytidylate kinase
+panC	TIGR00018	pantoate--beta-alanine ligase
+prfA	TIGR00019	peptide chain release factor 1
+prfB	TIGR00020	peptide chain release factor 2
+rpiA	TIGR00021	ribose 5-phosphate isomerase A
+TIGR00022	TIGR00022	YhcH/YjgK/YiaL family protein
+TIGR00023	TIGR00023	acyl-phosphate glycerol 3-phosphate acyltransferase
+SbcD_rel_arch	TIGR00024	putative phosphoesterase
+Mtu_efflux	TIGR00025	ABC transporter efflux protein, DrrB family
+hi_GC_TIGR00026	TIGR00026	deazaflavin-dependent oxidoreductase, nitroreductase family
+mthyl_TIGR00027	TIGR00027	methyltransferase, TIGR00027 family
+Mtu_PIN_fam	TIGR00028	toxin-antitoxin system PIN domain toxin
+S20	TIGR00029	ribosomal protein bS20
+S21p	TIGR00030	ribosomal protein bS21
+UDP-GALP_mutase	TIGR00031	UDP-galactopyranose mutase
+argG	TIGR00032	argininosuccinate synthase
+aroC	TIGR00033	chorismate synthase
+aroFGH	TIGR00034	3-deoxy-7-phosphoheptulonate synthase
+asp_race	TIGR00035	aspartate racemase
+dapB	TIGR00036	4-hydroxy-tetrahydrodipicolinate reductase
+eIF_5A	TIGR00037	translation elongation factor IF5A
+efp	TIGR00038	translation elongation factor P
+6PTHBS	TIGR00039	6-pyruvoyl tetrahydropterin synthase/QueD family protein
+yfcE	TIGR00040	phosphodiesterase, MJ0936 family
+DTMP_kinase	TIGR00041	dTMP kinase
+TIGR00042	TIGR00042	non-canonical purine NTP pyrophosphatase, RdgB/HAM1 family
+TIGR00043	TIGR00043	rRNA maturation RNase YbeY
+TIGR00044	TIGR00044	pyridoxal phosphate enzyme, YggS family
+TIGR00045	TIGR00045	glycerate kinase
+TIGR00046	TIGR00046	RNA methyltransferase, RsmE family
+rRNA_mod_RlmN	TIGR00048	23S rRNA (adenine(2503)-C(2))-methyltransferase
+TIGR00049	TIGR00049	iron-sulfur cluster assembly accessory protein
+rRNA_methyl_1	TIGR00050	RNA methyltransferase, TrmH family, group 1
+TIGR00051	TIGR00051	acyl-CoA thioester hydrolase, YbgC/YbaW family
+TIGR00052	TIGR00052	nudix-type nucleoside diphosphatase, YffH/AdpP family
+TIGR00053	TIGR00053	addiction module toxin component, YafQ family
+TIGR00054	TIGR00054	RIP metalloprotease RseP
+uppS	TIGR00055	di-trans,poly-cis-decaprenylcistransferase
+TIGR00056	TIGR00056	ABC transport permease subunit
+TIGR00057	TIGR00057	tRNA threonylcarbamoyl adenosine modification protein, Sua5/YciO/YrdC/YwlC family
+Hemerythrin	TIGR00058	hemerythrin family non-heme iron protein
+L17	TIGR00059	ribosomal protein bL17
+L18_bact	TIGR00060	ribosomal protein uL18
+L21	TIGR00061	ribosomal protein bL21
+L27	TIGR00062	ribosomal protein bL27
+folE	TIGR00063	GTP cyclohydrolase I
+ftsY	TIGR00064	signal recognition particle-docking protein FtsY
+ftsZ	TIGR00065	cell division protein FtsZ
+g_glut_trans	TIGR00066	gamma-glutamyltransferase
+glut_race	TIGR00067	glutamate racemase
+glyox_I	TIGR00068	lactoylglutathione lyase
+hisD	TIGR00069	histidinol dehydrogenase
+hisG	TIGR00070	ATP phosphoribosyltransferase
+hisT_truA	TIGR00071	tRNA pseudouridine(38-40) synthase
+hydrog_prot	TIGR00072	hydrogenase maturation protease
+hypB	TIGR00073	hydrogenase accessory protein HypB
+hypC_hupF	TIGR00074	hydrogenase assembly chaperone HypC/HupF
+hypD	TIGR00075	hydrogenase expression/formation protein HypD
+lspA	TIGR00077	signal peptidase II
+nadC	TIGR00078	nicotinate-nucleotide diphosphorylase (carboxylating)
+pept_deformyl	TIGR00079	peptide deformylase
+pimt	TIGR00080	protein-L-isoaspartate O-methyltransferase
+purC	TIGR00081	phosphoribosylaminoimidazolesuccinocarboxamide synthase
+rbfA	TIGR00082	ribosome-binding factor A
+ribF	TIGR00083	riboflavin biosynthesis protein RibF
+ruvA	TIGR00084	Holliday junction DNA helicase RuvA
+smpB	TIGR00086	SsrA-binding protein
+surE	TIGR00087	5'/3'-nucleotidase SurE
+trmD	TIGR00088	tRNA (guanine(37)-N(1))-methyltransferase
+TIGR00089	TIGR00089	radical SAM methylthiotransferase, MiaB/RimO family
+rsfS_iojap_ybeB	TIGR00090	ribosome silencing factor
+TIGR00091	TIGR00091	tRNA (guanine-N(7)-)-methyltransferase
+TIGR00092	TIGR00092	GTP-binding protein YchF
+TIGR00093	TIGR00093	pseudouridine synthase
+tRNA_TruD_broad	TIGR00094	tRNA pseudouridine synthase, TruD family
+TIGR00095	TIGR00095	16S rRNA (guanine(966)-N(2))-methyltransferase RsmD
+TIGR00096	TIGR00096	16S rRNA (cytidine(1402)-2'-O)-methyltransferase
+HMP-P_kinase	TIGR00097	hydroxymethylpyrimidine kinase/phosphomethylpyrimidine kinase
+Cof-subfamily	TIGR00099	Cof-like hydrolase
+hypA	TIGR00100	hydrogenase nickel insertion protein HypA
+ureG	TIGR00101	urease accessory protein UreG
+DNA_YbaB_EbfC	TIGR00103	DNA-binding protein, YbaB/EbfC family
+tRNA_TsaA	TIGR00104	tRNA-Thr(GGU) m(6)t(6)A37 methyltransferase TsaA
+L31	TIGR00105	ribosomal protein bL31
+TIGR00106	TIGR00106	uncharacterized protein, MTH1187 family
+deoD	TIGR00107	purine nucleoside phosphorylase
+hemH	TIGR00109	ferrochelatase
+ilvD	TIGR00110	dihydroxy-acid dehydratase
+pelota	TIGR00111	mRNA surveillance protein pelota
+proC	TIGR00112	pyrroline-5-carboxylate reductase
+queA	TIGR00113	S-adenosylmethionine:tRNA ribosyltransferase-isomerase
+lumazine-synth	TIGR00114	6,7-dimethyl-8-ribityllumazine synthase
+tig	TIGR00115	trigger factor
+tsf	TIGR00116	translation elongation factor Ts
+acnB	TIGR00117	aconitate hydratase 2
+acolac_lg	TIGR00118	acetolactate synthase, large subunit, biosynthetic type
+acolac_sm	TIGR00119	acetolactate synthase, small subunit
+ArgJ	TIGR00120	glutamate N-acetyltransferase/amino-acid acetyltransferase
+birA_ligase	TIGR00121	biotin--[acetyl-CoA-carboxylase] ligase
+birA_repr_reg	TIGR00122	biotin operon repressor
+cbiM	TIGR00123	cobalamin biosynthesis protein CbiM
+cit_ly_ligase	TIGR00124	[citrate (pro-3S)-lyase] ligase
+cyt_tran_rel	TIGR00125	cytidyltransferase-like domain
+deoC	TIGR00126	deoxyribose-phosphate aldolase
+nadp_idh_euk	TIGR00127	isocitrate dehydrogenase, NADP-dependent
+fabD	TIGR00128	malonyl CoA-acyl carrier protein transacylase
+fdhD_narQ	TIGR00129	formate dehydrogenase family accessory protein FdhD
+frhD	TIGR00130	coenzyme F420-reducing hydrogenase, FrhD protein
+gal_kin	TIGR00131	galactokinase
+gatA	TIGR00132	aspartyl/glutamyl-tRNA(Asn/Gln) amidotransferase, A subunit
+gatB	TIGR00133	aspartyl/glutamyl-tRNA(Asn/Gln) amidotransferase, B subunit
+gatE_arch	TIGR00134	glutamyl-tRNA(Gln) amidotransferase, subunit E
+gatC	TIGR00135	aspartyl/glutamyl-tRNA(Asn/Gln) amidotransferase, C subunit
+gidA	TIGR00136	tRNA uridine 5-carboxymethylaminomethyl modification enzyme GidA
+gid_trmFO	TIGR00137	tRNA:m(5)U-54 methyltransferase
+rsmG_gidB	TIGR00138	16S rRNA (guanine(527)-N(7))-methyltransferase RsmG
+h_aconitase	TIGR00139	homoaconitase
+hupD	TIGR00140	hydrogenase expression/formation protein
+hycI	TIGR00142	hydrogenase maturation peptidase HycI
+hypF	TIGR00143	carbamoyltransferase HypF
+beta_RFAP_syn	TIGR00144	beta-ribofuranosylaminobenzene 5'-phosphate synthase family
+TIGR00145	TIGR00145	FTR1 family protein
+TIGR00147	TIGR00147	lipid kinase, YegS/Rv2252/BmrU family
+TIGR00148	TIGR00148	decarboxylase, UbiD family
+TIGR00149_YjbQ	TIGR00149	secondary thiamine-phosphate synthase enzyme
+T6A_YjeE	TIGR00150	tRNA threonylcarbamoyl adenosine modification protein YjeE
+ispF	TIGR00151	2-C-methyl-D-erythritol 2,4-cyclodiphosphate synthase
+TIGR00152	TIGR00152	dephospho-CoA kinase
+TIGR00153	TIGR00153	TIGR00153 family protein
+ispE	TIGR00154	4-(cytidine 5'-diphospho)-2-C-methyl-D-erythritol kinase
+pqiA_fam	TIGR00155	integral membrane protein, PqiA family
+TIGR00156	TIGR00156	TIGR00156 family protein
+TIGR00157	TIGR00157	ribosome small subunit-dependent GTPase A
+L9	TIGR00158	ribosomal protein bL9
+TIGR00159	TIGR00159	TIGR00159 family protein
+MGSA	TIGR00160	methylglyoxal synthase
+TIGR00161	TIGR00161	TIGR00161 family protein
+TIGR00162	TIGR00162	TIGR00162 family protein
+PS_decarb	TIGR00163	phosphatidylserine decarboxylase
+PS_decarb_rel	TIGR00164	phosphatidylserine decarboxylase homolog
+S18	TIGR00165	ribosomal protein bS18
+S6	TIGR00166	ribosomal protein bS6
+cbbA	TIGR00167	ketose-bisphosphate aldolase
+infC	TIGR00168	translation initiation factor IF-3
+leuB	TIGR00169	3-isopropylmalate dehydrogenase
+leuC	TIGR00170	3-isopropylmalate dehydratase, large subunit
+leuD	TIGR00171	3-isopropylmalate dehydratase, small subunit
+maf	TIGR00172	septum formation protein Maf
+menD	TIGR00173	2-succinyl-5-enolpyruvyl-6-hydroxy-3-cyclohexene-1-carboxylic-acid synthase
+miaA	TIGR00174	tRNA dimethylallyltransferase
+mito_nad_idh	TIGR00175	isocitrate dehydrogenase, NAD-dependent
+mobB	TIGR00176	molybdopterin-guanine dinucleotide biosynthesis protein B
+molyb_syn	TIGR00177	molybdenum cofactor synthesis domain
+monomer_idh	TIGR00178	isocitrate dehydrogenase, NADP-dependent
+murB	TIGR00179	UDP-N-acetylenolpyruvoylglucosamine reductase
+parB_part	TIGR00180	ParB/RepB/Spo0J family partition protein
+pepF	TIGR00181	oligoendopeptidase F
+plsX	TIGR00182	fatty acid/phospholipid synthesis protein PlsX
+prok_nadp_idh	TIGR00183	isocitrate dehydrogenase, NADP-dependent
+purA	TIGR00184	adenylosuccinate synthase
+tRNA_yibK_trmL	TIGR00185	tRNA (cytidine(34)-2'-O)-methyltransferase
+rRNA_methyl_3	TIGR00186	RNA methyltransferase, TrmH family, group 3
+ribE	TIGR00187	riboflavin synthase, alpha subunit
+rnpA	TIGR00188	ribonuclease P protein component
+tesB	TIGR00189	acyl-CoA thioesterase II
+thiC	TIGR00190	phosphomethylpyrimidine synthase
+thrB	TIGR00191	homoserine kinase
+urease_beta	TIGR00192	urease, beta subunit
+urease_gam	TIGR00193	urease, gamma subunit
+uvrC	TIGR00194	excinuclease ABC subunit C
+exoDNase_III	TIGR00195	exodeoxyribonuclease III
+yjeF_cterm	TIGR00196	YjeF family C-terminal domain
+yjeF_nterm	TIGR00197	YjeF family N-terminal domain
+cat_per_HPI	TIGR00198	catalase/peroxidase HPI
+PncC_domain	TIGR00199	amidohydrolase, PncC family
+cinA_nterm	TIGR00200	competence/damage-inducible protein CinA N-terminal domain
+comF	TIGR00201	comF family protein
+csrA	TIGR00202	carbon storage regulator
+cydB	TIGR00203	cytochrome d ubiquinol oxidase, subunit II
+dxs	TIGR00204	1-deoxy-D-xylulose-5-phosphate synthase
+fliE	TIGR00205	flagellar hook-basal body complex protein FliE
+fliF	TIGR00206	flagellar M-ring protein FliF
+fliG	TIGR00207	flagellar motor switch protein FliG
+fliS	TIGR00208	flagellar protein FliS
+galT_1	TIGR00209	galactose-1-phosphate uridylyltransferase
+gltS	TIGR00210	sodium/glutamate symporter
+glyS	TIGR00211	glycine--tRNA ligase, beta subunit
+hemC	TIGR00212	hydroxymethylbilane synthase
+GmhB_yaeD	TIGR00213	D,D-heptose 1,7-bisphosphate phosphatase
+lipB	TIGR00214	lipoyl(octanoyl) transferase
+lpxB	TIGR00215	lipid-A-disaccharide synthase
+ispH_lytB	TIGR00216	4-hydroxy-3-methylbut-2-enyl diphosphate reductase
+malQ	TIGR00217	4-alpha-glucanotransferase
+manA	TIGR00218	mannose-6-phosphate isomerase, class I
+mreC	TIGR00219	rod shape-determining protein MreC
+mscL	TIGR00220	large conductance mechanosensitive channel protein
+nagA	TIGR00221	N-acetylglucosamine-6-phosphate deacetylase
+panB	TIGR00222	3-methyl-2-oxobutanoate hydroxymethyltransferase
+panD	TIGR00223	aspartate 1-decarboxylase
+pckA	TIGR00224	phosphoenolpyruvate carboxykinase (ATP)
+prc	TIGR00225	C-terminal processing peptidase
+ribD_Cterm	TIGR00227	riboflavin-specific deaminase C-terminal domain
+ruvC	TIGR00228	crossover junction endodeoxyribonuclease RuvC
+sensory_box	TIGR00229	PAS domain S-box protein
+sfsA	TIGR00230	sugar fermentation stimulation protein
+small_GTP	TIGR00231	small GTP-binding protein domain
+tktlase_bact	TIGR00232	transketolase
+trpS	TIGR00233	tryptophan--tRNA ligase
+tyrS	TIGR00234	tyrosine--tRNA ligase
+udk	TIGR00235	uridine kinase
+wecB	TIGR00236	UDP-N-acetylglucosamine 2-epimerase
+xseA	TIGR00237	exodeoxyribonuclease VII, large subunit
+TIGR00238	TIGR00238	KamA family protein
+2oxo_dh_E1	TIGR00239	oxoglutarate dehydrogenase (succinyl-transferring), E1 component
+ATCase_reg	TIGR00240	aspartate carbamoyltransferase, regulatory subunit
+CoA_E_activ	TIGR00241	putative CoA-substrate-specific enzyme activase
+TIGR00242	TIGR00242	division/cell wall cluster transcriptional repressor MraZ
+Dxr	TIGR00243	1-deoxy-D-xylulose 5-phosphate reductoisomerase
+TIGR00244	TIGR00244	transcriptional regulator NrdR
+TIGR00245	TIGR00245	TIGR00245 family protein
+tRNA_RlmH_YbeA	TIGR00246	rRNA large subunit m3Psi methyltransferase RlmH
+TIGR00247	TIGR00247	conserved hypothetical protein, YceG family
+sixA	TIGR00249	phosphohistidine phosphatase SixA
+RNAse_H_YqgF	TIGR00250	putative transcription antitermination factor YqgF
+TIGR00251	TIGR00251	TIGR00251 family protein
+TIGR00252	TIGR00252	TIGR00252 family protein
+RNA_bind_YhbY	TIGR00253	putative RNA-binding protein, YhbY family
+GGDEF	TIGR00254	diguanylate cyclase (GGDEF) domain
+TIGR00255	TIGR00255	TIGR00255 family protein
+TIGR00256	TIGR00256	D-tyrosyl-tRNA(Tyr) deacylase
+IMPACT_YIGZ	TIGR00257	uncharacterized protein, YigZ family
+TIGR00258	TIGR00258	inosine/xanthosine triphosphatase
+thylakoid_BtpA	TIGR00259	membrane complex biogenesis protein, BtpA family
+thrC	TIGR00260	threonine synthase
+traB	TIGR00261	TraB family protein
+trpA	TIGR00262	tryptophan synthase, alpha subunit
+trpB	TIGR00263	tryptophan synthase, beta subunit
+TIGR00264	TIGR00264	alpha-NAC homolog
+TIGR00266	TIGR00266	TIGR00266 family protein
+TIGR00267	TIGR00267	TIGR00267 family protein
+TIGR00268	TIGR00268	TIGR00268 family protein
+TIGR00269	TIGR00269	TIGR00269 family protein
+TIGR00270	TIGR00270	TIGR00270 family protein
+TIGR00271	TIGR00271	uncharacterized hydrophobic domain
+DPH2	TIGR00272	diphthamide biosynthesis protein 2
+TIGR00273	TIGR00273	iron-sulfur cluster-binding protein
+TIGR00274	TIGR00274	N-acetylmuramic acid 6-phosphate etherase
+TIGR00275	TIGR00275	flavoprotein, HI0933 family
+TIGR00276	TIGR00276	epoxyqueuosine reductase
+HDIG	TIGR00277	HDIG domain
+TIGR00278	TIGR00278	putative membrane protein insertion efficiency factor
+uL16_euk_arch	TIGR00279	ribosomal protein uL16
+eL43_euk_arch	TIGR00280	ribosomal protein eL43
+TIGR00281	TIGR00281	segregation and condensation protein B
+TIGR00282	TIGR00282	metallophosphoesterase, MG_246/BB_0505 family
+arch_pth2	TIGR00283	peptidyl-tRNA hydrolase
+TIGR00284	TIGR00284	dihydropteroate synthase-related protein
+TIGR00285	TIGR00285	DNA-binding protein Alba
+TIGR00286	TIGR00286	arginine decarboxylase, pyruvoyl-dependent
+cas1	TIGR00287	CRISPR-associated endonuclease Cas1
+TIGR00288	TIGR00288	TIGR00288 family protein
+TIGR00289	TIGR00289	TIGR00289 family protein
+MJ0570_dom	TIGR00290	MJ0570-related uncharacterized domain
+RNA_SBDS	TIGR00291	rRNA metabolism protein, SBDS family
+TIGR00292	TIGR00292	thiazole biosynthesis enzyme
+TIGR00293	TIGR00293	prefoldin, alpha subunit
+TIGR00294	TIGR00294	GTP cyclohydrolase
+TIGR00295	TIGR00295	TIGR00295 family protein
+TIGR00296	TIGR00296	uncharacterized protein, PH0010 family
+TIGR00297	TIGR00297	TIGR00297 family protein
+TIGR00298	TIGR00298	2-phosphosulfolactate phosphatase
+TIGR00299	TIGR00299	TIGR00299 family protein
+TIGR00300	TIGR00300	TIGR00300 family protein
+TIGR00302	TIGR00302	phosphoribosylformylglycinamidine synthase, purS protein
+TIGR00303	TIGR00303	TIGR00303 family protein
+TIGR00304	TIGR00304	TIGR00304 family protein
+TIGR00305	TIGR00305	putative toxin-antitoxin system toxin component, PIN family
+apgM	TIGR00306	phosphoglycerate mutase (2,3-diphosphoglycerate-independent), archaeal form
+eS8	TIGR00307	ribosomal protein eS8
+TRM1	TIGR00308	N2,N2-dimethylguanosine tRNA methyltransferase
+V_ATPase_subD	TIGR00309	V-type ATPase, D subunit
+ZPR1_znf	TIGR00310	ZPR1 zinc finger domain
+aIF-2beta	TIGR00311	putative translation initiation factor aIF-2, beta subunit
+cbiD	TIGR00312	cobalamin biosynthesis protein CbiD
+cobQ	TIGR00313	cobyric acid synthase CobQ
+cdhA	TIGR00314	CO dehydrogenase/acetyl-CoA synthase complex, epsilon subunit
+cdhB	TIGR00315	CO dehydrogenase/acetyl-CoA synthase complex, epsilon subunit
+cdhC	TIGR00316	CO dehydrogenase/CO-methylating acetyl-CoA synthase complex, beta subunit
+cobS	TIGR00317	cobalamin 5'-phosphate synthase
+cyaB	TIGR00318	putative adenylyl cyclase CyaB
+desulf_FeS4	TIGR00319	desulfoferrodoxin FeS4 iron-binding domain
+dfx_rbo	TIGR00320	desulfoferrodoxin
+dhys	TIGR00321	deoxyhypusine synthase
+diphth2_R	TIGR00322	diphthamide biosynthesis enzyme Dph1/Dph2 domain
+eIF-6	TIGR00323	putative translation initiation factor eIF-6
+endA	TIGR00324	tRNA-intron lyase
+lpxC	TIGR00325	UDP-3-O-[3-hydroxymyristoyl] N-acetylglucosamine deacetylase
+eubact_ribD	TIGR00326	riboflavin biosynthesis protein RibD
+secE_euk_arch	TIGR00327	protein translocase SEC61 complex gamma subunit, archaeal and eukaryotic
+flhB	TIGR00328	flagellar biosynthetic protein FlhB
+gcp_kae1	TIGR00329	metallohydrolase, glycoprotease/Kae1 family
+glpX	TIGR00330	fructose-1,6-bisphosphatase, class II
+hrcA	TIGR00331	heat-inducible transcription repressor HrcA
+neela_ferrous	TIGR00332	desulfoferrodoxin ferrous iron-binding domain
+nrdI	TIGR00333	nrdI protein
+5S_RNA_mat_M5	TIGR00334	ribonuclease M5
+primase_sml	TIGR00335	putative DNA primase, eukaryotic-type, small subunit
+pyrE	TIGR00336	orotate phosphoribosyltransferase
+PyrG	TIGR00337	CTP synthase
+serB	TIGR00338	phosphoserine phosphatase SerB
+sopT	TIGR00339	sulfate adenylyltransferase
+zpr1_rel	TIGR00340	zinc finger protein ZPR1 homolog
+TIGR00341	TIGR00341	TIGR00341 family protein
+TIGR00342	TIGR00342	tRNA sulfurtransferase ThiI
+TIGR00343	TIGR00343	pyridoxal 5'-phosphate synthase, synthase subunit Pdx1
+alaS	TIGR00344	alanine--tRNA ligase
+GET3_arsA_TRC40	TIGR00345	transport-energizing ATPase, TRC40/GET3/ArsA family
+azlC	TIGR00346	azaleucine resistance protein AzlC
+bioD	TIGR00347	dethiobiotin synthase
+hsdR	TIGR00348	type I site-specific deoxyribonuclease, HsdR family
+lytR_cpsA_psr	TIGR00350	cell envelope-related function transcriptional attenuator common domain
+narI	TIGR00351	respiratory nitrate reductase, gamma subunit
+nrfE	TIGR00353	cytochrome c-type biogenesis protein CcmF
+polC	TIGR00354	DNA polymerase II, large subunit DP2
+purH	TIGR00355	phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase
+TIGR00357	TIGR00357	methionine-R-sulfoxide reductase
+3_prime_RNase	TIGR00358	VacB and RNase II family 3'-5' exoribonucleases
+cello_pts_IIC	TIGR00359	PTS system, cellobiose-specific IIC component
+ComEC_N-term	TIGR00360	ComEC/Rec2-related protein
+ComEC_Rec2	TIGR00361	DNA internalization-related competence protein ComEC/Rec2
+DnaA	TIGR00362	chromosomal replication initiator protein DnaA
+TIGR00363	TIGR00363	lipoprotein, YaeC family
+TIGR00364	TIGR00364	queuosine biosynthesis protein QueC
+TIGR00365	TIGR00365	monothiol glutaredoxin, Grx4 family
+TIGR00366	TIGR00366	TIGR00366 family protein
+TIGR00367	TIGR00367	K+-dependent Na+/Ca+ exchanger homolog
+TIGR00368	TIGR00368	Mg chelatase-like protein
+unchar_dom_1	TIGR00369	uncharacterized domain 1
+TIGR00370	TIGR00370	sensor histidine kinase inhibitor, KipI family
+cas4	TIGR00372	CRISPR-associated protein Cas4
+TIGR00373	TIGR00373	transcription factor E
+TIGR00374	TIGR00374	TIGR00374 family protein
+TIGR00375	TIGR00375	TIGR00375 family protein
+TIGR00376	TIGR00376	putative DNA helicase
+ant_ant_sig	TIGR00377	anti-anti-sigma factor
+cax	TIGR00378	calcium/proton exchanger
+cobB	TIGR00379	cobyrinic acid a,c-diamide synthase
+cobD	TIGR00380	cobalamin biosynthesis protein CobD
+cdhD	TIGR00381	CO dehydrogenase/acetyl-CoA synthase, delta subunit
+clpX	TIGR00382	ATP-dependent Clp protease, ATP-binding subunit ClpX
+corA	TIGR00383	magnesium and cobalt transport protein CorA
+dhsB	TIGR00384	succinate dehydrogenase and fumarate reductase iron-sulfur protein
+dsbE	TIGR00385	periplasmic protein thiol:disulfide oxidoreductases, DsbE subfamily
+glcD	TIGR00387	glycolate oxidase, subunit GlcD
+glyQ	TIGR00388	glycine--tRNA ligase, alpha subunit
+glyS_dimeric	TIGR00389	glycine--tRNA ligase
+hslU	TIGR00390	ATP-dependent protease HslVU, ATPase subunit
+hydA	TIGR00391	hydrogenase (NiFe) small subunit (hydA)
+ileS	TIGR00392	isoleucine--tRNA ligase
+kpsF	TIGR00393	sugar isomerase, KpsF/GutQ family
+lac_pts_IIC	TIGR00394	PTS system, lactose-specific IIC component
+leuS_arch	TIGR00395	leucine--tRNA ligase
+leuS_bact	TIGR00396	leucine--tRNA ligase
+mauM_napG	TIGR00397	MauM/NapG family ferredoxin-type protein
+metG	TIGR00398	methionine--tRNA ligase
+metG_C_term	TIGR00399	methionine--tRNA ligase, beta subunit
+mgtE	TIGR00400	magnesium transporter
+msrA	TIGR00401	peptide-methionine (S)-S-oxide reductase
+napF	TIGR00402	ferredoxin-type protein NapF
+ndhI	TIGR00403	NADH-plastoquinone oxidoreductase, I subunit
+KOW_elon_Spt5	TIGR00405	transcription elongation factor Spt5
+prmA	TIGR00406	ribosomal protein L11 methyltransferase
+proA	TIGR00407	glutamate-5-semialdehyde dehydrogenase
+proS_fam_I	TIGR00408	proline--tRNA ligase
+proS_fam_II	TIGR00409	proline--tRNA ligase
+lacE	TIGR00410	PTS system, lactose/cellobiose family IIC component
+redox_disulf_1	TIGR00411	redox-active disulfide protein 1
+redox_disulf_2	TIGR00412	redox-active disulfide protein 2
+rlpA	TIGR00413	rare lipoprotein A
+serS	TIGR00414	serine--tRNA ligase
+serS_MJ	TIGR00415	serine--tRNA ligase
+sms	TIGR00416	DNA repair protein RadA
+speE	TIGR00417	spermidine synthase
+thrS	TIGR00418	threonine--tRNA ligase
+tim	TIGR00419	triose-phosphate isomerase
+trmU	TIGR00420	tRNA (5-methylaminomethyl-2-thiouridylate)-methyltransferase
+ubiX_pad	TIGR00421	polyprenyl P-hydroxybenzoate and phenylacrylic acid decarboxylases
+valS	TIGR00422	valine--tRNA ligase
+TIGR00423	TIGR00423	radical SAM domain protein, CofH subfamily
+APS_reduc	TIGR00424	5'-adenylylsulfate reductase, thioredoxin-independent
+CBF5	TIGR00425	putative rRNA pseudouridine synthase
+TIGR00426	TIGR00426	competence protein ComEA helix-hairpin-helix repeat region
+TIGR00427	TIGR00427	membrane protein, MarC family
+Q_tRNA_tgt	TIGR00430	tRNA-guanine transglycosylase
+TruB	TIGR00431	tRNA pseudouridine(55) synthase
+arcsn_tRNA_tgt	TIGR00432	tRNA-guanine(15) transglycosylase
+bioB	TIGR00433	biotin synthase
+cysH	TIGR00434	phosophoadenylyl-sulfate reductase
+cysS	TIGR00435	cysteine--tRNA ligase
+era	TIGR00436	GTP-binding protein Era
+feoB	TIGR00437	ferrous iron transport protein B
+rrmJ	TIGR00438	ribosomal RNA large subunit methyltransferase J
+ftsX	TIGR00439	putative protein insertion permease FtsX
+glnS	TIGR00440	glutamine--tRNA ligase
+gmhA	TIGR00441	phosphoheptose isomerase
+hisS	TIGR00442	histidine--tRNA ligase
+hisZ_biosyn_reg	TIGR00443	ATP phosphoribosyltransferase, regulatory subunit
+mazG	TIGR00444	MazG family protein
+mraY	TIGR00445	phospho-N-acetylmuramoyl-pentapeptide-transferase
+nop2p	TIGR00446	NOL1/NOP2/sun family putative RNA methylase
+pth	TIGR00447	aminoacyl-tRNA hydrolase
+rpoE	TIGR00448	DNA-directed RNA polymerase
+tgt_general	TIGR00449	tRNA-guanine family transglycosylase
+mnmE_trmE_thdF	TIGR00450	tRNA modification GTPase TrmE
+unchar_dom_2	TIGR00451	uncharacterized domain 2
+TIGR00452	TIGR00452	tRNA (mo5U34)-methyltransferase
+ispD	TIGR00453	2-C-methyl-D-erythritol 4-phosphate cytidylyltransferase
+TIGR00454	TIGR00454	TIGR00454 family protein
+apsK	TIGR00455	adenylyl-sulfate kinase
+argS	TIGR00456	arginine--tRNA ligase
+asnS	TIGR00457	asparagine--tRNA ligase
+aspS_nondisc	TIGR00458	aspartate--tRNA(Asn) ligase
+aspS_bact	TIGR00459	aspartate--tRNA ligase
+fmt	TIGR00460	methionyl-tRNA formyltransferase
+gcvP	TIGR00461	glycine dehydrogenase
+genX	TIGR00462	EF-P lysine aminoacylase GenX
+gltX_arch	TIGR00463	glutamate--tRNA ligase
+gltX_bact	TIGR00464	glutamate--tRNA ligase
+ilvC	TIGR00465	ketol-acid reductoisomerase
+kdsB	TIGR00466	3-deoxy-D-manno-octulosonate cytidylyltransferase
+lysS_arch	TIGR00467	lysine--tRNA ligase
+pheS	TIGR00468	phenylalanine--tRNA ligase, alpha subunit
+pheS_mito	TIGR00469	phenylalanine--tRNA ligase
+sepS	TIGR00470	O-phosphoserine--tRNA ligase
+pheT_arch	TIGR00471	phenylalanine--tRNA ligase, beta subunit
+pheT_bact	TIGR00472	phenylalanine--tRNA ligase, beta subunit
+pssA	TIGR00473	CDP-diacylglycerol-serine O-phosphatidyltransferase
+selA	TIGR00474	L-seryl-tRNA(Sec) selenium transferase
+selB	TIGR00475	selenocysteine-specific translation elongation factor
+selD	TIGR00476	selenide, water dikinase
+tehB	TIGR00477	tellurite resistance protein TehB
+tly	TIGR00478	TlyA family rRNA methyltransferase/putative hemolysin
+rumA	TIGR00479	23S rRNA (uracil-5-)-methyltransferase RumA
+TIGR00481	TIGR00481	Raf kinase inhibitor-like protein, YbhB/YbcL family
+TIGR00482	TIGR00482	nicotinate (nicotinamide) nucleotide adenylyltransferase
+EF-1_alpha	TIGR00483	translation elongation factor EF-1, subunit alpha
+EF-G	TIGR00484	translation elongation factor G
+EF-Tu	TIGR00485	translation elongation factor Tu
+YbgI_SA1388	TIGR00486	dinuclear metal center protein, YbgI/SA1388 family
+IF-2	TIGR00487	translation initiation factor IF-2
+TIGR00488	TIGR00488	putative HD superfamily hydrolase
+aEF-1_beta	TIGR00489	translation elongation factor aEF-1 beta
+aEF-2	TIGR00490	translation elongation factor aEF-2
+aIF-2	TIGR00491	translation initiation factor aIF-2
+alr	TIGR00492	alanine racemase
+clpP	TIGR00493	ATP-dependent Clp endopeptidase, proteolytic subunit ClpP
+crcB	TIGR00494	protein CrcB
+crvDNA_42K	TIGR00495	DNA-binding protein, 42 kDa
+frr	TIGR00496	ribosome recycling factor
+hsdM	TIGR00497	type I restriction-modification system, M subunit
+lexA	TIGR00498	repressor LexA
+lysS_bact	TIGR00499	lysine--tRNA ligase
+met_pdase_I	TIGR00500	methionine aminopeptidase, type I
+met_pdase_II	TIGR00501	methionine aminopeptidase, type II
+nagB	TIGR00502	glucosamine-6-phosphate deaminase
+prfC	TIGR00503	peptide chain release factor 3
+pyro_pdase	TIGR00504	pyroglutamyl-peptidase I
+ribA	TIGR00505	GTP cyclohydrolase II
+ribB	TIGR00506	3,4-dihydroxy-2-butanone-4-phosphate synthase
+aroE	TIGR00507	shikimate dehydrogenase
+bioA	TIGR00508	adenosylmethionine-8-amino-7-oxononanoate transaminase
+bisC_fam	TIGR00509	molybdopterin guanine dinucleotide-containing S/N-oxide reductases
+lipA	TIGR00510	lipoyl synthase
+ribulose_e2b2	TIGR00511	ribose-1,5-bisphosphate isomerase, e2b2 family
+salvage_mtnA	TIGR00512	S-methyl-5-thioribose-1-phosphate isomerase
+accA	TIGR00513	acetyl-CoA carboxylase, carboxyl transferase, alpha subunit
+accC	TIGR00514	acetyl-CoA carboxylase, biotin carboxylase subunit
+accD	TIGR00515	acetyl-CoA carboxylase, carboxyl transferase, beta subunit
+acpS	TIGR00516	holo-[acyl-carrier-protein] synthase
+acyl_carrier	TIGR00517	acyl carrier protein
+alaDH	TIGR00518	alanine dehydrogenase
+asnASE_I	TIGR00519	L-asparaginase, type I
+asnASE_II	TIGR00520	L-asparaginase, type II
+coaBC_dfp	TIGR00521	phosphopantothenoylcysteine decarboxylase / phosphopantothenate--cysteine ligase
+dph5	TIGR00522	diphthine synthase
+eIF-1A	TIGR00523	translation initiation factor eIF-1A
+eIF-2B_rel	TIGR00524	eIF-2B alpha/beta/delta-related uncharacterized proteins
+folB	TIGR00525	dihydroneopterin aldolase
+folB_dom	TIGR00526	FolB domain
+gcvH	TIGR00527	glycine cleavage system H protein
+gcvT	TIGR00528	glycine cleavage system T protein
+AF0261	TIGR00529	integral membrane protein, TIGR00529 family
+AGP_acyltrn	TIGR00530	1-acylglycerol-3-phosphate O-acyltransferases
+BCCP	TIGR00531	acetyl-CoA carboxylase, biotin carboxyl carrier protein
+HMG_CoA_R_NAD	TIGR00532	hydroxymethylglutaryl-CoA reductase, degradative
+HMG_CoA_R_NADP	TIGR00533	hydroxymethylglutaryl-CoA reductase (NADPH)
+OpcA	TIGR00534	glucose-6-phosphate dehydrogenase assembly protein OpcA
+SAM_DCase	TIGR00535	S-adenosylmethionine decarboxylase proenzyme
+hemK_fam	TIGR00536	methyltransferase, HemK family
+hemK_rel_arch	TIGR00537	putative methylase
+hemN	TIGR00538	oxygen-independent coproporphyrinogen III oxidase
+hemN_rel	TIGR00539	putative oxygen-independent coproporphyrinogen III oxidase
+TPR_hemY_coli	TIGR00540	heme biosynthesis-associated TPR protein
+hisDCase_pyru	TIGR00541	histidine decarboxylase, pyruvoyl type
+hxl6Piso_put	TIGR00542	putative hexulose-6-phosphate isomerase
+isochor_syn	TIGR00543	isochorismate synthase
+lgt	TIGR00544	prolipoprotein diacylglyceryl transferase
+lipoyltrans	TIGR00545	lipoyltransferase and lipoate-protein ligase
+lnt	TIGR00546	apolipoprotein N-acyltransferase
+lolA	TIGR00547	outer membrane lipoprotein carrier protein LolA
+lolB	TIGR00548	outer membrane lipoprotein LolB
+mevalon_kin	TIGR00549	mevalonate kinase
+nadA	TIGR00550	quinolinate synthetase complex, A subunit
+nadB	TIGR00551	L-aspartate oxidase
+nadE	TIGR00552	NAD+ synthetase
+pabB	TIGR00553	aminodeoxychorismate synthase, component I
+panK_bact	TIGR00554	pantothenate kinase
+panK_eukar	TIGR00555	pantothenate kinase
+pantethn_trn	TIGR00556	phosphopantetheine--protein transferase domain
+pdxA	TIGR00557	4-hydroxythreonine-4-phosphate dehydrogenase PdxA
+pdxH	TIGR00558	pyridoxamine 5'-phosphate oxidase
+pdxJ	TIGR00559	pyridoxine 5'-phosphate synthase
+pgsA	TIGR00560	CDP-diacylglycerol--glycerol-3-phosphate 3-phosphatidyltransferase
+pntA	TIGR00561	NAD(P)(+) transhydrogenase (AB-specific), alpha subunit
+proto_IX_ox	TIGR00562	protoporphyrinogen oxidase
+rsmB	TIGR00563	16S rRNA (cytosine(967)-C(5))-methyltransferase
+trpE_most	TIGR00564	anthranilate synthase component I
+trpE_proteo	TIGR00565	anthranilate synthase component I
+trpG_papA	TIGR00566	glutamine amidotransferase of anthranilate synthase or aminodeoxychorismate synthase
+3mg	TIGR00567	DNA-3-methyladenine glycosylase
+alkb	TIGR00568	alkylated DNA repair protein AlkB
+ccl1	TIGR00569	cyclin ccl1
+cdk7	TIGR00570	CDK-activating kinase assembly factor MAT1
+dam	TIGR00571	DNA adenine methylase
+dnaq	TIGR00573	exonuclease, DNA polymerase III, epsilon subunit family
+dnl1	TIGR00574	DNA ligase I, ATP-dependent (dnl1)
+dnlj	TIGR00575	DNA ligase, NAD-dependent
+dut	TIGR00576	dUTP diphosphatase
+fpg	TIGR00577	DNA-formamidopyrimidine glycosylase
+ku70	TIGR00578	ATP-dependent DNA helicase II, 70 kDa subunit (ku70)
+mfd	TIGR00580	transcription-repair coupling factor
+moaC	TIGR00581	molybdenum cofactor biosynthesis protein C
+mre11	TIGR00583	DNA repair protein (mre11)
+mug	TIGR00584	mismatch-specific thymine-DNA glycosylate (mug)
+mutl	TIGR00585	DNA mismatch repair protein MutL
+mutt	TIGR00586	mutator mutT protein
+nfo	TIGR00587	apurinic endonuclease (APN1)
+ogg	TIGR00588	8-oxoguanine DNA-glycosylase (ogg)
+ogt	TIGR00589	methylated-DNA--[protein]-cysteine S-methyltransferase
+pcna	TIGR00590	proliferating cell nuclear antigen (pcna)
+phr2	TIGR00591	deoxyribodipyrimidine photolyase
+pol2	TIGR00592	DNA polymerase (pol2)
+pola	TIGR00593	DNA polymerase I
+polc	TIGR00594	DNA polymerase III, alpha subunit
+priA	TIGR00595	primosomal protein N'
+rad1	TIGR00596	DNA repair protein (rad1)
+rad10	TIGR00597	DNA repair protein rad10
+rad14	TIGR00598	DNA repair protein
+rad18	TIGR00599	DNA repair protein rad18
+rad2	TIGR00600	DNA excision repair protein (rad2)
+rad23	TIGR00601	UV excision repair protein Rad23
+rad24	TIGR00602	checkpoint protein rad24
+rad25	TIGR00603	DNA repair helicase rad25
+rad3	TIGR00604	DNA repair helicase (rad3)
+rad4	TIGR00605	DNA repair protein rad4
+rad50	TIGR00606	rad50
+rad52	TIGR00607	recombination protein rad52
+radc	TIGR00608	DNA repair protein RadC
+recB	TIGR00609	exodeoxyribonuclease V, beta subunit
+recf	TIGR00611	DNA replication and repair protein RecF
+ispG_gcpE	TIGR00612	4-hydroxy-3-methylbut-2-en-1-yl diphosphate synthase
+reco	TIGR00613	DNA repair protein RecO
+recQ_fam	TIGR00614	ATP-dependent DNA helicase, RecQ family
+recR	TIGR00615	recombination protein RecR
+rect	TIGR00616	recombinase, phage RecT family
+rpa1	TIGR00617	replication factor-a protein 1 (rpa1)
+sbcc	TIGR00618	exonuclease SbcC
+sbcd	TIGR00619	exonuclease SbcCD, D subunit
+ssb	TIGR00621	single-stranded DNA-binding protein
+ssl1	TIGR00622	transcription factor ssl1
+sula	TIGR00623	cell division inhibitor SulA
+tag	TIGR00624	DNA-3-methyladenine glycosylase I
+tfb2	TIGR00625	transcription factor Tfb2
+tfb4	TIGR00627	transcription factor tfb4
+ung	TIGR00628	uracil-DNA glycosylase
+uvde	TIGR00629	UV damage endonuclease UvdE
+uvra	TIGR00630	excinuclease ABC subunit A
+uvrb	TIGR00631	excinuclease ABC subunit B
+vsr	TIGR00632	DNA mismatch endonuclease Vsr
+xth	TIGR00633	exodeoxyribonuclease III (xth)
+recN	TIGR00634	DNA repair protein RecN
+ruvB	TIGR00635	Holliday junction DNA helicase RuvB
+PduO_Nterm	TIGR00636	ATP:cob(I)alamin adenosyltransferase
+ModE_repress	TIGR00637	ModE molybdate transport repressor domain
+Mop	TIGR00638	molybdenum-pterin binding domain
+PurN	TIGR00639	phosphoribosylglycinamide formyltransferase
+acid_CoA_mut_C	TIGR00640	methylmalonyl-CoA mutase C-terminal domain
+acid_CoA_mut_N	TIGR00641	methylmalonyl-CoA mutase N-terminal domain
+mmCoA_mut_beta	TIGR00642	methylmalonyl-CoA mutase, small subunit
+recG	TIGR00643	ATP-dependent DNA helicase RecG
+recJ	TIGR00644	single-stranded-DNA-specific exonuclease RecJ
+HI0507	TIGR00645	TIGR00645 family protein
+MG010	TIGR00646	DNA primase-like protein
+DNA_bind_WhiA	TIGR00647	DNA-binding protein WhiA
+recU	TIGR00648	recombination protein U
+MG423	TIGR00649	beta-CASP ribonuclease, RNase J family
+pta	TIGR00651	phosphate acetyltransferase
+DapF	TIGR00652	diaminopimelate epimerase
+GlnA	TIGR00653	glutamine synthetase, type I
+PhzF_family	TIGR00654	phenazine biosynthesis protein, PhzF family
+PurU	TIGR00655	formyltetrahydrofolate deformylase
+asp_kin_monofn	TIGR00656	aspartate kinase, monofunctional class
+asp_kinases	TIGR00657	aspartate kinase
+orni_carb_tr	TIGR00658	ornithine carbamoyltransferase
+TIGR00659	TIGR00659	TIGR00659 family protein
+MJ1255	TIGR00661	conserved hypothetical protein
+dnan	TIGR00663	DNA polymerase III, beta subunit
+DNA_III_psi	TIGR00664	DNA polymerase III, psi subunit
+DnaB	TIGR00665	replicative DNA helicase
+PBP4	TIGR00666	D-alanyl-D-alanine carboxypeptidase/D-alanyl-D-alanine-endopeptidase
+aat	TIGR00667	leucyl/phenylalanyl-tRNA--protein transferase
+apaH	TIGR00668	bis(5'-nucleosyl)-tetraphosphatase (symmetrical)
+asnA	TIGR00669	aspartate--ammonia ligase
+asp_carb_tr	TIGR00670	aspartate carbamoyltransferase
+baf	TIGR00671	pantothenate kinase, type III
+cdh	TIGR00672	CDP-diacylglycerol diphosphatase
+cynS	TIGR00673	cyanase
+dapA	TIGR00674	4-hydroxy-tetrahydrodipicolinate synthase
+dcm	TIGR00675	DNA (cytosine-5-)-methyltransferase
+fadh2	TIGR00676	methylenetetrahydrofolate reductase [NAD(P)H]
+fadh2_euk	TIGR00677	methylenetetrahydrofolate reductase
+holB	TIGR00678	DNA polymerase III, delta' subunit
+hpr-ser	TIGR00679	HPr(Ser) kinase/phosphatase
+kdpA	TIGR00680	K+-transporting ATPase, A subunit
+kdpC	TIGR00681	K+-transporting ATPase, C subunit
+lpxK	TIGR00682	tetraacyldisaccharide 4'-kinase
+nanA	TIGR00683	N-acetylneuraminate lyase
+narJ	TIGR00684	nitrate reductase molybdenum cofactor assembly chaperone
+T6PP	TIGR00685	trehalose-phosphatase
+phnA	TIGR00686	putative alkylphosphonate utilization operon protein PhnA
+pyridox_kin	TIGR00687	pyridoxal kinase
+rarD	TIGR00688	protein RarD
+rpiB_lacA_lacB	TIGR00689	sugar-phosphate isomerase, RpiB/LacA/LacB family
+rpoZ	TIGR00690	DNA-directed RNA polymerase, omega subunit
+spoT_relA	TIGR00691	RelA/SpoT family protein
+tdh	TIGR00692	L-threonine 3-dehydrogenase
+thiE	TIGR00693	thiamine-phosphate diphosphorylase
+thiM	TIGR00694	hydroxyethylthiazole kinase
+uxuA	TIGR00695	mannonate dehydratase
+wecG_tagA_cpsF	TIGR00696	glycosyltransferase, WecB/TagA/CpsF family
+TIGR00697	TIGR00697	conserved hypothetical integral membrane protein
+TIGR00698	TIGR00698	conserved hypothetical protein
+GABAtrns_euk	TIGR00699	4-aminobutyrate aminotransferase
+GABAtrnsam	TIGR00700	4-aminobutyrate transaminase
+TIGR00701	TIGR00701	TIGR00701 family protein
+TIGR00702	TIGR00702	YcaO-type kinase domain
+TIGR00703	TIGR00703	TIGR00703 family protein
+NaPi_cotrn_rel	TIGR00704	Na/Pi-cotransporter II-related protein
+SppA_67K	TIGR00705	signal peptide peptidase SppA, 67K type
+SppA_dom	TIGR00706	signal peptide peptidase SppA, 36K type
+argD	TIGR00707	transaminase, acetylornithine/succinylornithine family
+cobA	TIGR00708	cob(I)yrinic acid a,c-diamide adenosyltransferase
+dat	TIGR00709	2,4-diaminobutyrate 4-transaminase
+efflux_Bcr_CflA	TIGR00710	drug resistance transporter, Bcr/CflA subfamily
+efflux_EmrB	TIGR00711	drug resistance MFS transporter, drug:H+ antiporter-2 (14 Spanner) (DHA2) family
+glpT	TIGR00712	glycerol-3-phosphate transporter
+hemL	TIGR00713	glutamate-1-semialdehyde-2,1-aminomutase
+hscB	TIGR00714	Fe-S protein assembly co-chaperone HscB
+precor6x_red	TIGR00715	precorrin-6x reductase
+rnhC	TIGR00716	ribonuclease HIII
+rpsA	TIGR00717	ribosomal protein bS1
+sda_alpha	TIGR00718	L-serine dehydratase, iron-sulfur-dependent, alpha subunit
+sda_beta	TIGR00719	L-serine dehydratase, iron-sulfur-dependent, beta subunit
+sda_mono	TIGR00720	L-serine ammonia-lyase
+tfx	TIGR00721	DNA-binding protein, Tfx family
+ttdA_fumA_fumB	TIGR00722	hydrolyase, tartrate alpha subunit/fumarate domain protein, Fe-S type
+ttdB_fumA_fumB	TIGR00723	hydrolyase, tartrate beta subunit/fumarate domain protein, Fe-S type
+urea_amlyse_rel	TIGR00724	biotin-dependent carboxylase uncharacterized domain
+TIGR00725	TIGR00725	TIGR00725 family protein
+TIGR00726	TIGR00726	YfiH family protein
+ISP4_OPT	TIGR00727	small oligopeptide transporter, OPT family
+OPT_sfam	TIGR00728	oligopeptide transporter, OPT superfamily
+TIGR00729	TIGR00729	ribonuclease HII
+TIGR00730	TIGR00730	TIGR00730 family protein
+bL25_bact_ctc	TIGR00731	ribosomal protein bL25, Ctc-form
+dprA	TIGR00732	DNA protecting protein DprA
+TIGR00733	TIGR00733	oligopeptide transporter, OPT family
+hisAF_rel	TIGR00734	hisA/hisF family protein
+hisF	TIGR00735	imidazoleglycerol phosphate synthase, cyclase subunit
+nifR3_rel_arch	TIGR00736	putative TIM-barrel protein
+nifR3_yhdG	TIGR00737	putative TIM-barrel protein, nifR3 family
+rrf2_super	TIGR00738	Rrf2 family protein
+yajC	TIGR00739	preprotein translocase, YajC subunit
+TIGR00740	TIGR00740	tRNA (cmo5U34)-methyltransferase
+yfiA	TIGR00741	ribosomal subunit interface protein
+yjbN	TIGR00742	tRNA dihydrouridine synthase A
+TIGR00743	TIGR00743	conserved hypothetical protein
+ROK_glcA_fam	TIGR00744	ROK family protein (putative glucokinase)
+apbA_panE	TIGR00745	2-dehydropantoate 2-reductase
+arcC	TIGR00746	carbamate kinase
+fabH	TIGR00747	3-oxoacyl-[acyl-carrier-protein] synthase III
+HMG_CoA_syn_Arc	TIGR00748	putative hydroxymethylglutaryl-CoA synthase
+glk	TIGR00749	glucokinase
+lao	TIGR00750	LAO/AO transport system ATPase
+menA	TIGR00751	1,4-dihydroxy-2-naphthoate octaprenyltransferase
+slp	TIGR00752	outer membrane lipoprotein, Slp family
+undec_PP_bacA	TIGR00753	undecaprenyl-diphosphatase UppP
+bfr	TIGR00754	bacterioferritin
+ksgA	TIGR00755	ribosomal RNA small subunit methyltransferase A
+PPR	TIGR00756	pentatricopeptide repeat domain
+RNaseEG	TIGR00757	ribonuclease, Rne/Rng family
+UDG_fam4	TIGR00758	uracil-DNA glycosylase, family 4
+aceE	TIGR00759	pyruvate dehydrogenase (acetyl-transferring), homodimeric type
+araD	TIGR00760	L-ribulose-5-phosphate 4-epimerase
+argB	TIGR00761	acetylglutamate kinase
+DegV	TIGR00762	EDD domain protein, DegV family
+lon	TIGR00763	endopeptidase La
+lon_rel	TIGR00764	putative ATP-dependent protease
+yihY_not_rbn	TIGR00765	YihY family inner membrane protein
+TIGR00766	TIGR00766	inner membrane protein YhjD
+rho	TIGR00767	transcription termination factor Rho
+rimK_fam	TIGR00768	alpha-L-glutamate ligase, RimK family
+AAA	TIGR00769	ADP/ATP carrier protein family
+Dcu	TIGR00770	transporter, anaerobic C4-dicarboxylate uptake (Dcu) family
+DcuC	TIGR00771	transporter, anaerobic C4-dicarboxylate uptake C (DcuC) family
+NhaA	TIGR00773	Na+/H+ antiporter NhaA
+NhaB	TIGR00774	Na+/H+ antiporter NhaB
+NhaD	TIGR00775	Na+/H+ antiporter, NhaD family
+RhaT	TIGR00776	RhaT L-rhamnose-proton symporter family protein
+ahpD	TIGR00777	alkylhydroperoxidase, AhpD family
+ahpD_dom	TIGR00778	alkylhydroperoxidase AhpD family core domain
+cad	TIGR00779	cadmium resistance transporter family protein
+ccoN	TIGR00780	cytochrome c oxidase, cbb3-type, subunit I
+ccoO	TIGR00781	cytochrome c oxidase, cbb3-type, subunit II
+ccoP	TIGR00782	cytochrome c oxidase, cbb3-type, subunit III
+ccs	TIGR00783	citrate carrier protein, CCS family
+citMHS	TIGR00784	citrate transporter
+dass	TIGR00785	transporter, divalent anion:Na+ symporter (DASS) family
+dctM	TIGR00786	TRAP transporter, DctM subunit
+dctP	TIGR00787	TRAP transporter solute receptor, DctP family
+fbt	TIGR00788	folate/biopterin transporter
+flhB_rel	TIGR00789	FlhB domain protein
+fnt	TIGR00790	formate/nitrite transporter
+gntP	TIGR00791	transporter, gluconate:H+ symporter (GntP) family
+gph	TIGR00792	sugar (Glycoside-Pentoside-Hexuronide) transporter
+kdgT	TIGR00793	2-keto-3-deoxygluconate transporter
+kup	TIGR00794	potassium uptake protein
+lctP	TIGR00795	transporter, lactate permease (LctP) family
+livcs	TIGR00796	branched-chain amino acid transport system II carrier protein
+matE	TIGR00797	MATE efflux family protein
+mtc	TIGR00798	tricarboxylate carrier
+mtp	TIGR00799	Golgi 4-transmembrane spanning transporter
+ncs1	TIGR00800	NCS1 nucleoside transporter family
+ncs2	TIGR00801	uracil-xanthine permease
+nico	TIGR00802	transition metal uptake transporter, Ni2+-Co2+ transporter (NiCoT) family
+nst	TIGR00803	UDP-galactose transporter
+nupC	TIGR00804	nucleoside transporter, NupC family
+oat	TIGR00805	sodium-independent organic anion transporter
+rfc	TIGR00806	reduced folate carrier
+malonate_madL	TIGR00807	malonate transporter, MadL subunit
+malonate_madM	TIGR00808	malonate transporter, MadM subunit
+secB	TIGR00809	protein-export chaperone SecB
+secG	TIGR00810	preprotein translocase, SecG subunit
+sit	TIGR00811	silicon transporter
+sss	TIGR00813	transporter, solute:sodium symporter (SSS) family
+stp	TIGR00814	serine transporter
+sulP	TIGR00815	sulfate permease
+tdt	TIGR00816	C4-dicarboxylate transporter/malic acid transport protein
+tpt	TIGR00817	Tpt phosphate/phosphoenolpyruvate translocator
+ydaH	TIGR00819	AbgT transporter family
+zip	TIGR00820	ZIP zinc/iron transport family
+EII-GUT	TIGR00821	PTS system, glucitol/sorbitol-specific, IIC component
+EII-Sor	TIGR00822	PTS system, mannose/fructose/sorbose family, IIC component
+EIIA-LAC	TIGR00823	PTS system, lactose-specific IIa component
+EIIA-man	TIGR00824	PTS system, mannose/fructose/sorbose family, IIA component
+EIIBC-GUT	TIGR00825	PTS system, glucitol/sorbitol-specific, IIBC component
+EIIB_glc	TIGR00826	PTS system, glucose-like IIB component
+EIIC-GAT	TIGR00827	PTS system, galactitol-specific IIC component
+EIID-AGA	TIGR00828	PTS system, mannose/fructose/sorbose family, IID component
+FRU	TIGR00829	PTS system, Fru family, IIB component
+PTBA	TIGR00830	PTS system, glucose subfamily, IIA component
+a_cpa1	TIGR00831	Na+/H+ antiporter
+acr3	TIGR00832	arsenical-resistance protein
+actII	TIGR00833	transport protein
+ae	TIGR00834	anion exchange protein
+agcS	TIGR00835	amino acid carrier protein
+amt	TIGR00836	ammonium transporter
+araaP	TIGR00837	aromatic amino acid transport protein
+argH	TIGR00838	argininosuccinate lyase
+aspA	TIGR00839	aspartate ammonia-lyase
+b_cpa1	TIGR00840	sodium/hydrogen exchanger 3
+bass	TIGR00841	bile acid transporter
+bcct	TIGR00842	transporter, betaine/carnitine/choline transporter (BCCT) family
+benE	TIGR00843	benzoate transporter
+c_cpa1	TIGR00844	sodium/hydrogen antiporter
+caca	TIGR00845	sodium/calcium exchanger 1
+caca2	TIGR00846	calcium/proton exchanger
+ccoS	TIGR00847	cytochrome oxidase maturation protein, cbb3-type
+fruA	TIGR00848	PTS system, fructose subfamily, IIA component
+gutA	TIGR00849	PTS system, glucitol/sorbitol-specific IIA component
+mtlA	TIGR00851	PTS system, mannitol-specific IIC component
+pts-Glc	TIGR00852	PTS system, maltose and glucose-specific subfamily, IIC component
+pts-lac	TIGR00853	PTS system, lactose/cellobiose family IIB component
+pts-sorbose	TIGR00854	PTS system, mannose/fructose/sorbose family, IIB component
+L12	TIGR00855	ribosomal protein bL12
+pyrC_dimer	TIGR00856	dihydroorotase, homodimeric type
+pyrC_multi	TIGR00857	dihydroorotase, multifunctional complex type
+bioF	TIGR00858	8-amino-7-oxononanoate synthase
+ENaC	TIGR00859	sodium channel transporter
+LIC	TIGR00860	cation transporter family protein
+MIP	TIGR00861	MIP family channel proteins
+O-ClC	TIGR00862	intracellular chloride channel protein
+P2X	TIGR00863	cation transporter protein
+PCC	TIGR00864	polycystin cation channel protein
+bcl-2	TIGR00865	apoptosis regulator
+deg-1	TIGR00867	degenerin
+hCaCC	TIGR00868	calcium-activated chloride channel protein 1
+sec62	TIGR00869	protein translocation protein, Sec62 family
+trp	TIGR00870	transient-receptor-potential calcium channel protein
+zwf	TIGR00871	glucose-6-phosphate dehydrogenase
+gnd_rel	TIGR00872	6-phosphogluconate dehydrogenase (decarboxylating)
+gnd	TIGR00873	6-phosphogluconate dehydrogenase (decarboxylating)
+talAB	TIGR00874	transaldolase
+fsa_talC_mipB	TIGR00875	fructose-6-phosphate aldolase
+tal_mycobact	TIGR00876	transaldolase
+purD	TIGR00877	phosphoribosylamine--glycine ligase
+purM	TIGR00878	phosphoribosylformylglycinamidine cyclo-ligase
+SP	TIGR00879	MFS transporter, sugar porter (SP) family
+2_A_01_02	TIGR00880	multidrug resistance protein
+2A0104	TIGR00881	phosphoglycerate transporter family protein
+2A0105	TIGR00882	oligosaccharide:H+ symporter
+2A0106	TIGR00883	MFS transporter, metabolite:H+ symporter (MHS) family protein
+guaA_Cterm	TIGR00884	GMP synthase (glutamine-hydrolyzing), C-terminal domain
+fucP	TIGR00885	L-fucose:H+ symporter permease
+2A0108	TIGR00886	nitrite transporter
+2A0109	TIGR00887	phosphate:H+ symporter
+guaA_Nterm	TIGR00888	GMP synthase (glutamine-hydrolyzing), N-terminal domain
+2A0110	TIGR00889	nucleoside transporter
+2A0111	TIGR00890	oxalate/formate antiporter family transporter
+2A0112	TIGR00891	MFS transporter, sialate:H+ symporter (SHS) family
+2A0113	TIGR00892	monocarboxylate transporter
+2A0114	TIGR00893	D-galactonate transporter
+2A0114euk	TIGR00894	Na(+)-dependent inorganic phosphate cotransporter
+2A0115	TIGR00895	MFS transporter, aromatic acid:H+ symporter (AAHS) family
+CynX	TIGR00896	cyanate transporter
+2A0118	TIGR00897	polyol permease
+2A0119	TIGR00898	cation transport protein
+2A0120	TIGR00899	sugar efflux transporter
+2A0121	TIGR00900	H+ Antiporter protein
+2A0125	TIGR00901	AmpG-like permease
+2A0127	TIGR00902	MFS transporter, phenyl propionate permease (PPP) family
+2A0129	TIGR00903	major facilitator 4 family protein
+mreB	TIGR00904	cell shape determining protein, MreB/Mrl family
+2A0302	TIGR00905	transporter, basic amino acid/polyamine antiporter (APA) family
+2A0303	TIGR00906	cationic amino acid transport permease
+2A0304	TIGR00907	amino acid permease
+2A0305	TIGR00908	ethanolamine permease
+2A0306	TIGR00909	amino acid transporter
+2A0307_GadC	TIGR00910	glutamate:gamma-aminobutyrate antiporter
+2A0308	TIGR00911	L-type amino acid transporter
+2A0309	TIGR00912	spore germination protein (amino acid permease)
+2A0310	TIGR00913	amino acid permease (yeast)
+2A0601	TIGR00914	heavy metal efflux pump, CzcA family
+2A0602	TIGR00915	RND transporter, hydrophobe/amphiphile efflux-1 (HAE1) family
+2A0604s01	TIGR00916	protein-export membrane protein, SecD/SecF family
+2A060601	TIGR00917	Niemann-Pick C type protein family
+2A060602	TIGR00918	transmembrane receptor Patched
+2A060605	TIGR00920	3-hydroxy-3-methylglutaryl-coenzyme A reductase
+2A067	TIGR00921	efflux transporter, putative, hydrophobe/amphiphile efflux-3 (HAE3) family
+nusG	TIGR00922	transcription termination/antitermination factor NusG
+yjdL_sub1_fam	TIGR00924	amino acid/peptide transporter (Peptide:H+ symporter)
+2A1704	TIGR00926	oligopeptide transporter, peptide:H+ symporter
+2A1904	TIGR00927	K+-dependent Na+/Ca+ exchanger
+purB	TIGR00928	adenylosuccinate lyase
+VirB4_CagE	TIGR00929	type IV secretion/conjugal transfer ATPase, VirB4 family
+2a30	TIGR00930	K-Cl cotransporter
+antiport_nhaC	TIGR00931	Na+/H+ antiporter NhaC
+2a37	TIGR00932	transporter, monovalent cation:proton antiporter-2 (CPA2) family
+2a38	TIGR00933	potassium uptake protein, TrkH family
+2a38euk	TIGR00934	potassium uptake protein, Trk family
+2a45	TIGR00935	arsenite/antimonite efflux pump membrane protein
+ahcY	TIGR00936	adenosylhomocysteinase
+2A51	TIGR00937	chromate efflux transporter
+thrB_alt	TIGR00938	homoserine kinase
+2a57	TIGR00939	nucleoside Transporter
+2a6301s01	TIGR00940	monovalent cation:proton antiporter
+2a6301s03	TIGR00941	multicomponent Na+:H+ antiporter, MnhC subunit
+2a6301s05	TIGR00942	multicomponent Na+:H+ antiporter
+2a6301s02	TIGR00943	monovalent cation:proton antiporter
+2a6301s04	TIGR00944	multicomponent K+:H+antiporter
+tatC	TIGR00945	twin arginine-targeting protein translocase TatC
+2a69	TIGR00946	auxin efflux carrier
+2A73	TIGR00947	putative bicarbonate transporter, IctB family
+2a75	TIGR00948	L-lysine exporter
+2A76	TIGR00949	homoserine/Threonine efflux protein
+2A78	TIGR00950	carboxylate/amino acid/amine transporter
+2A43	TIGR00951	lysosomal Cystine Transporter
+S15_bact	TIGR00952	ribosomal protein uS15
+3a01203	TIGR00954	peroxysomal long chain fatty acyl transporter
+3a01204	TIGR00955	pigment precursor permease
+3a01205	TIGR00956	pleiotropic drug resistance family protein
+MRP_assoc_pro	TIGR00957	multi drug resistance-associated protein (MRP)
+3a01208	TIGR00958	antigen peptide transporter 2
+ffh	TIGR00959	signal recognition particle protein
+atpA	TIGR00962	ATP synthase F1, alpha subunit
+secA	TIGR00963	preprotein translocase, SecA subunit
+secE_bact	TIGR00964	preprotein translocase, SecE subunit
+dapD	TIGR00965	2,3,4,5-tetrahydropyridine-2,6-dicarboxylate N-succinyltransferase
+3a0501s07	TIGR00966	protein-export membrane protein SecF
+3a0501s007	TIGR00967	preprotein translocase, SecY subunit
+3a0106s01	TIGR00968	sulfate ABC transporter, ATP-binding protein
+3a0106s02	TIGR00969	sulfate ABC transporter, permease protein
+leuA_yeast	TIGR00970	2-isopropylmalate synthase
+3a0106s03	TIGR00971	sulfate ABC transporter, sulfate-binding protein
+3a0107s01c2	TIGR00972	phosphate ABC transporter, ATP-binding protein
+leuA_bact	TIGR00973	2-isopropylmalate synthase
+3a0107s02c	TIGR00974	phosphate ABC transporter, permease protein PstA
+3a0107s03	TIGR00975	phosphate ABC transporter, phosphate-binding protein PstS
+/NonD	TIGR00976	hydrolase CocE/NonD family protein
+citramal_synth	TIGR00977	citramalate synthase
+asd_EA	TIGR00978	aspartate-semialdehyde dehydrogenase
+fumC_II	TIGR00979	fumarate hydratase, class II
+3a0801so1tim17	TIGR00980	mitochondrial import inner membrane translocase subunit tim17
+rpsL_bact	TIGR00981	ribosomal protein uS12
+uS12_E_A	TIGR00982	ribosomal protein uS12
+3a0801s02tim23	TIGR00983	mitochondrial import inner membrane translocase subunit
+3a0801s03tim44	TIGR00984	mitochondrial import inner membrane, translocase subunit
+3a0801s04tom	TIGR00985	mitochondrial import receptor subunit
+3a0801s05tom22	TIGR00986	mitochondrial import receptor subunit
+himA	TIGR00987	integration host factor, alpha subunit
+hip	TIGR00988	integration host factor, beta subunit
+3a0801s07tom40	TIGR00989	mitochondrial import receptor subunit
+3a0801s09	TIGR00990	mitochondrial precursor proteins import receptor
+3a0901s02IAP34	TIGR00991	GTP-binding protein
+3a0901s03IAP75	TIGR00992	chloroplast envelope protein translocase, IAP75 family
+3a0901s04IAP86	TIGR00993	chloroplast protein import component Toc86/159, G and M domains
+3a0901s05TIC20	TIGR00994	chloroplast protein import component, Tic20 family
+3a0901s06TIC22	TIGR00995	chloroplast protein import component, Tic22 family
+Mtu_fam_mce	TIGR00996	virulence factor Mce family protein
+ispZ	TIGR00997	intracellular septation protein A
+8a0101	TIGR00998	efflux pump membrane protein
+8a0102	TIGR00999	membrane fusion protein cluster 2 protein
+bacteriocin_acc	TIGR01000	bacteriocin secretion accessory protein
+metA	TIGR01001	homoserine O-succinyltransferase
+hlyII	TIGR01002	beta-channel forming cytolysin
+PTS_HPr_family	TIGR01003	phosphocarrier, HPr family
+PulS_OutS	TIGR01004	lipoprotein, PulS/OutS family
+eps_transp_fam	TIGR01005	exopolysaccharide transport protein family
+polys_exp_MPA1	TIGR01006	polysaccharide export protein, MPA1 family
+eps_fam	TIGR01007	capsular exopolysaccharide family
+uS3_euk_arch	TIGR01008	ribosomal protein uS3
+rpsC_bact	TIGR01009	ribosomal protein uS3
+BexC_CtrB_KpsE	TIGR01010	polysaccharide export inner-membrane protein, BexC/CtrB/KpsE family
+rpsB_bact	TIGR01011	ribosomal protein uS2
+uS2_euk_arch	TIGR01012	ribosomal protein uS2
+2a58	TIGR01013	sodium-dependent inorganic phosphate (Pi) transporter
+hmgA	TIGR01015	homogentisate 1,2-dioxygenase
+sucCoAbeta	TIGR01016	succinate-CoA ligase, beta subunit
+rpsD_bact	TIGR01017	ribosomal protein uS4
+uS4_arch	TIGR01018	ribosomal protein uS4
+sucCoAalpha	TIGR01019	succinate-CoA ligase, alpha subunit
+uS5_euk_arch	TIGR01020	ribosomal protein uS5
+rpsE_bact	TIGR01021	ribosomal protein uS5
+rpmJ_bact	TIGR01022	ribosomal protein bL36
+rpmG_bact	TIGR01023	ribosomal protein bL33
+rplS_bact	TIGR01024	ribosomal protein bL19
+uS19_arch	TIGR01025	ribosomal protein uS19
+fliI_yscN	TIGR01026	ATPase, FliI/YscN family
+proB	TIGR01027	glutamate 5-kinase
+uS7_euk_arch	TIGR01028	ribosomal protein uS7
+rpsG_bact	TIGR01029	ribosomal protein uS7
+rpmH_bact	TIGR01030	ribosomal protein bL34
+rpmF_bact	TIGR01031	ribosomal protein bL32
+rplT_bact	TIGR01032	ribosomal protein bL20
+TIGR01033	TIGR01033	DNA-binding regulatory protein, YebC/PmpR family
+metK	TIGR01034	methionine adenosyltransferase
+hemA	TIGR01035	glutamyl-tRNA reductase
+pyrD_sub2	TIGR01036	dihydroorotate dehydrogenase (fumarate)
+pyrD_sub1_fam	TIGR01037	dihydroorotate dehydrogenase family protein
+uL22_arch_euk	TIGR01038	ribosomal protein uL22
+atpD	TIGR01039	ATP synthase F1, beta subunit
+V-ATPase_V1_B	TIGR01040	V-type ATPase, B subunit
+ATP_syn_B_arch	TIGR01041	ATP synthase archaeal, B subunit
+V-ATPase_V1_A	TIGR01042	V-type ATPase, A subunit
+ATP_syn_A_arch	TIGR01043	ATP synthase archaeal, A subunit
+rplV_bact	TIGR01044	ribosomal protein uL22
+RPE1	TIGR01045	rickettsial palindromic element RPE1 domain
+uS10_euk_arch	TIGR01046	ribosomal protein uS10
+nspC	TIGR01047	carboxynorspermidine decarboxylase
+lysA	TIGR01048	diaminopimelate decarboxylase
+rpsJ_bact	TIGR01049	ribosomal protein uS10
+rpsS_bact	TIGR01050	ribosomal protein uS19
+topA_bact	TIGR01051	DNA topoisomerase I
+top6b	TIGR01052	DNA topoisomerase VI, B subunit
+LSD1	TIGR01053	zinc finger domain, LSD1 subclass
+rgy	TIGR01054	reverse gyrase
+parE_Gneg	TIGR01055	DNA topoisomerase IV, B subunit
+topB	TIGR01056	DNA topoisomerase III
+topA_arch	TIGR01057	DNA topoisomerase I
+parE_Gpos	TIGR01058	DNA topoisomerase IV, B subunit
+gyrB	TIGR01059	DNA gyrase, B subunit
+eno	TIGR01060	phosphopyruvate hydratase
+parC_Gpos	TIGR01061	DNA topoisomerase IV, A subunit
+parC_Gneg	TIGR01062	DNA topoisomerase IV, A subunit
+gyrA	TIGR01063	DNA gyrase, A subunit
+pyruv_kin	TIGR01064	pyruvate kinase
+hlyIII	TIGR01065	channel protein, hemolysin III family
+rplM_bact	TIGR01066	ribosomal protein uL13
+rplN_bact	TIGR01067	ribosomal protein uL14
+thioredoxin	TIGR01068	thioredoxin
+mutS2	TIGR01069	MutS2 family protein
+mutS1	TIGR01070	DNA mismatch repair protein MutS
+rplO_bact	TIGR01071	ribosomal protein uL15
+murA	TIGR01072	UDP-N-acetylglucosamine 1-carboxyvinyltransferase
+pcrA	TIGR01073	ATP-dependent DNA helicase PcrA
+rep	TIGR01074	ATP-dependent DNA helicase Rep
+uvrD	TIGR01075	DNA helicase II
+sortase_fam	TIGR01076	sortase
+L13_A_E	TIGR01077	ribosomal protein uL13
+arcA	TIGR01078	arginine deiminase
+rplX_bact	TIGR01079	ribosomal protein uL24
+rplX_A_E	TIGR01080	ribosomal protein uL24
+mpl	TIGR01081	UDP-N-acetylmuramate:L-alanyl-gamma-D-glutamyl-meso-diaminopimelate ligase
+murC	TIGR01082	UDP-N-acetylmuramate--L-alanine ligase
+nth	TIGR01083	endonuclease III
+mutY	TIGR01084	A/G-specific adenine glycosylase
+murE	TIGR01085	UDP-N-acetylmuramyl-tripeptide synthetase
+fucA	TIGR01086	L-fuculose phosphate aldolase
+murD	TIGR01087	UDP-N-acetylmuramoylalanine--D-glutamate ligase
+aroQ	TIGR01088	3-dehydroquinate dehydratase, type II
+fucI	TIGR01089	L-fucose isomerase
+apt	TIGR01090	adenine phosphoribosyltransferase
+upp	TIGR01091	uracil phosphoribosyltransferase
+P5CS	TIGR01092	delta l-pyrroline-5-carboxylate synthetase
+aroD	TIGR01093	3-dehydroquinate dehydratase, type I
+3A0103s03R	TIGR01096	lysine-arginine-ornithine-binding periplasmic protein
+PhnE	TIGR01097	phosphonate ABC transporter, permease protein PhnE
+3A0109s03R	TIGR01098	phosphate/phosphite/phosphonate ABC transporter, periplasmic binding protein
+galU	TIGR01099	UTP--glucose-1-phosphate uridylyltransferase
+V_ATP_synt_C	TIGR01100	V-type ATPase, C subunit
+V_ATP_synt_F	TIGR01101	V-type ATPase, F subunit
+yscR	TIGR01102	type III secretion apparatus protein, YscR/HrcR family
+fliP	TIGR01103	flagellar biosynthetic protein FliP
+V_PPase	TIGR01104	V-type H(+)-translocating pyrophosphatase
+galF	TIGR01105	regulatory protein GalF
+ATPase-IIC_X-K	TIGR01106	Na,H/K antiporter P-type ATPase, alpha subunit
+Na_K_ATPase_bet	TIGR01107	Na+/K+ ATPase, beta subunit
+oadA	TIGR01108	oxaloacetate decarboxylase alpha subunit
+Na_pump_decarbB	TIGR01109	sodium ion-translocating decarboxylase, beta subunit
+mdcA	TIGR01110	malonate decarboxylase, alpha subunit
+mtrA	TIGR01111	tetrahydromethanopterin S-methyltransferase, subunit A
+mtrD	TIGR01112	tetrahydromethanopterin S-methyltransferase, subunit D
+mtrE	TIGR01113	tetrahydromethanopterin S-methyltransferase, subunit E
+mtrH	TIGR01114	N5-methyltetrahydromethanopterin:coenzyme M methyltransferase subunit H
+pufM	TIGR01115	photosynthetic reaction center M subunit
+ATPase-IIA1_Ca	TIGR01116	calcium-translocating P-type ATPase, SERCA-type
+mmdA	TIGR01117	methylmalonyl-CoA decarboxylase alpha subunit
+lacA	TIGR01118	galactose-6-phosphate isomerase, LacA subunit
+lacB	TIGR01119	galactose-6-phosphate isomerase, LacB subunit
+rpiB	TIGR01120	ribose 5-phosphate isomerase B
+D_amino_aminoT	TIGR01121	D-amino-acid transaminase
+ilvE_I	TIGR01122	branched-chain amino acid aminotransferase
+ilvE_II	TIGR01123	branched-chain amino acid aminotransferase
+ilvA_2Cterm	TIGR01124	threonine ammonia-lyase, biosynthetic
+TIGR01125	TIGR01125	ribosomal protein S12 methylthiotransferase RimO
+pdi_dom	TIGR01126	protein disulfide-isomerase domain
+ilvA_1Cterm	TIGR01127	threonine ammonia-lyase
+holA	TIGR01128	DNA polymerase III, delta subunit
+secD	TIGR01129	protein-export membrane protein SecD
+ER_PDI_fam	TIGR01130	protein disulfide isomerase
+ATP_synt_6_or_A	TIGR01131	ATP synthase F0, A subunit
+pgm	TIGR01132	phosphoglucomutase, alpha-D-glucose phosphate-specific
+murG	TIGR01133	undecaprenyldiphospho-muramoylpentapeptide beta-N-acetylglucosaminyltransferase
+purF	TIGR01134	amidophosphoribosyltransferase
+glmS	TIGR01135	glutamine-fructose-6-phosphate transaminase (isomerizing)
+cysKM	TIGR01136	cysteine synthase
+cysta_beta	TIGR01137	cystathionine beta-synthase
+cysM	TIGR01138	cysteine synthase B
+cysK	TIGR01139	cysteine synthase A
+L_thr_O3P_dcar	TIGR01140	threonine-phosphate decarboxylase
+hisC	TIGR01141	histidinol-phosphate transaminase
+purT	TIGR01142	phosphoribosylglycinamide formyltransferase 2
+murF	TIGR01143	UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase
+ATP_synt_b	TIGR01144	ATP synthase F0, B subunit
+ATP_synt_delta	TIGR01145	ATP synthase F1, delta subunit
+ATPsyn_F1gamma	TIGR01146	ATP synthase F1, gamma subunit
+V_ATP_synt_G	TIGR01147	V-type ATPase, G subunit
+mtrC	TIGR01148	tetrahydromethanopterin S-methyltransferase, subunit C
+mtrG	TIGR01149	tetrahydromethanopterin S-methyltransferase, subunit G
+puhA	TIGR01150	photosynthetic reaction center H subunit
+psbA	TIGR01151	photosystem II q(b) protein
+psbD	TIGR01152	photosystem II D2 protein (photosystem q(a) protein)
+psbC	TIGR01153	photosystem II 44 kDa subunit reaction center protein
+cytb6/f_IV	TIGR01156	cytb6/f complex subunit IV
+pufL	TIGR01157	photosynthetic reaction center L subunit
+SUI1_rel	TIGR01158	putative translation initiation factor SUI1
+DRP1	TIGR01159	density-regulated protein DRP1
+SUI1_MOF2	TIGR01160	translation initiation factor SUI1
+purK	TIGR01161	phosphoribosylaminoimidazole carboxylase, ATPase subunit
+purE	TIGR01162	phosphoribosylaminoimidazole carboxylase, catalytic subunit
+rpe	TIGR01163	ribulose-phosphate 3-epimerase
+rplP_bact	TIGR01164	ribosomal protein uL16
+cbiN	TIGR01165	cobalt transport protein
+cbiO	TIGR01166	cobalt ABC transporter, ATP-binding protein
+LPXTG_anchor	TIGR01167	LPXTG cell wall anchor domain
+YSIRK_signal	TIGR01168	gram-positive signal peptide, YSIRK family
+rplA_bact	TIGR01169	ribosomal protein uL1
+rplA_mito	TIGR01170	ribosomal protein uL1, mitochondrial
+rplB_bact	TIGR01171	ribosomal protein uL2
+cysE	TIGR01172	serine O-acetyltransferase
+glmU	TIGR01173	UDP-N-acetylglucosamine diphosphorylase/glucosamine-1-phosphate N-acetyltransferase
+ftsA	TIGR01174	cell division protein FtsA
+pilM	TIGR01175	type IV pilus assembly protein PilM
+fum_red_Fp	TIGR01176	fumarate reductase (quinol), flavoprotein subunit
+TIGR01177	TIGR01177	putative methyltransferase, TIGR01177 family
+ade	TIGR01178	adenine deaminase
+galE	TIGR01179	UDP-glucose 4-epimerase GalE
+aman2_put	TIGR01180	putative alpha-1,2-mannosidase
+dTDP_gluc_dehyt	TIGR01181	dTDP-glucose 4,6-dehydratase
+eda	TIGR01182	2-dehydro-3-deoxyphosphogluconate aldolase/4-hydroxy-2-oxoglutarate aldolase
+ntrB	TIGR01183	nitrate ABC transporter, permease protein
+ntrCD	TIGR01184	nitrate ABC transporter, ATP-binding proteins C and D
+devC	TIGR01185	ABC exporter transmembrane subunit, DevC protein
+proV	TIGR01186	glycine betaine/L-proline transport ATP binding subunit
+potA	TIGR01187	polyamine ABC transporter, ATP-binding protein
+drrA	TIGR01188	daunorubicin resistance ABC transporter, ATP-binding protein
+ccmA	TIGR01189	heme ABC exporter, ATP-binding protein CcmA
+ccmB	TIGR01190	heme exporter protein CcmB
+ccmC	TIGR01191	heme exporter protein CcmC
+chvA	TIGR01192	glucan exporter ATP-binding protein
+bacteriocin_ABC	TIGR01193	ABC-type bacteriocin transporter
+cyc_pep_trnsptr	TIGR01194	cyclic peptide transporter
+oadG_fam	TIGR01195	sodium pump decarboxylases, gamma subunit
+edd	TIGR01196	phosphogluconate dehydratase
+nramp	TIGR01197	metal ion transporter, metal ion (Mn2+/Fe2+) transporter (Nramp) family
+pgl	TIGR01198	6-phosphogluconolactonase
+GLPGLI	TIGR01200	GLPGLI family protein
+HU_rel	TIGR01201	putative DNA-binding protein
+bchC	TIGR01202	chlorophyll synthesis pathway protein BchC
+HGPRTase	TIGR01203	hypoxanthine phosphoribosyltransferase
+bioW	TIGR01204	6-carboxyhexanoate--CoA ligase
+D_ala_D_alaTIGR	TIGR01205	D-alanine--D-alanine ligase
+lysW	TIGR01206	lysine biosynthesis protein LysW
+rmlA	TIGR01207	glucose-1-phosphate thymidylyltransferase
+rmlA_long	TIGR01208	glucose-1-phosphate thymidylyltransferase
+TIGR01209	TIGR01209	RNA ligase, Pab1020 family
+TIGR01210	TIGR01210	radical SAM enzyme, TIGR01210 family
+ELP3	TIGR01211	radical SAM enzyme/protein acetyltransferase, ELP3 family
+TIGR01212	TIGR01212	radical SAM protein, TIGR01212 family
+pseudo_Pus10arc	TIGR01213	tRNA pseudouridine(54/55) synthase
+rmlD	TIGR01214	dTDP-4-dehydrorhamnose reductase
+minE	TIGR01215	cell division topological specificity factor MinE
+ATP_synt_epsi	TIGR01216	ATP synthase F1, epsilon subunit
+ac_ac_CoA_syn	TIGR01217	acetoacetate-CoA ligase
+Gpos_tandem_5TM	TIGR01218	tandem five-TM protein
+Pmev_kin_ERG8	TIGR01219	phosphomevalonate kinase
+Pmev_kin_Gr_pos	TIGR01220	phosphomevalonate kinase
+rmlC	TIGR01221	dTDP-4-dehydrorhamnose 3,5-epimerase
+minC	TIGR01222	septum site-determining protein MinC
+Pmev_kin_anim	TIGR01223	phosphomevalonate kinase
+hutI	TIGR01224	imidazolonepropionase
+hutH	TIGR01225	histidine ammonia-lyase
+phe_am_lyase	TIGR01226	phenylalanine ammonia-lyase
+hutG	TIGR01227	formimidoylglutamase
+hutU	TIGR01228	urocanate hydratase
+rocF_arginase	TIGR01229	arginase
+agmatinase	TIGR01230	agmatinase
+lacC	TIGR01231	tagatose-6-phosphate kinase
+lacD	TIGR01232	tagatose 1,6-diphosphate aldolase
+lacG	TIGR01233	6-phospho-beta-galactosidase
+L-ribulokinase	TIGR01234	ribulokinase
+pyruv_carbox	TIGR01235	pyruvate carboxylase
+D1pyr5carbox1	TIGR01236	1-pyrroline-5-carboxylate dehydrogenase
+D1pyr5carbox2	TIGR01237	putative delta-1-pyrroline-5-carboxylate dehydrogenase
+D1pyr5carbox3	TIGR01238	delta-1-pyrroline-5-carboxylate dehydrogenase
+galT_2	TIGR01239	galactose-1-phosphate uridylyltransferase
+mevDPdecarb	TIGR01240	diphosphomevalonate decarboxylase
+FtsH_fam	TIGR01241	ATP-dependent metallopeptidase HflB
+26Sp45	TIGR01242	26S proteasome subunit P45 family
+CDC48	TIGR01243	AAA family ATPase, CDC48 subfamily
+TIGR01244	TIGR01244	TIGR01244 family protein
+trpD	TIGR01245	anthranilate phosphoribosyltransferase
+dapE_proteo	TIGR01246	succinyl-diaminopimelate desuccinylase
+drrB	TIGR01247	daunorubicin resistance ABC transporter membrane protein
+drrC	TIGR01248	daunorubicin resistance protein C
+pro_imino_pep_1	TIGR01249	prolyl aminopeptidase
+pro_imino_pep_2	TIGR01250	proline-specific peptidase
+ribP_PPkin	TIGR01251	ribose-phosphate diphosphokinase
+acetolac_decarb	TIGR01252	alpha-acetolactate decarboxylase
+thiP	TIGR01253	thiamine/thiamine pyrophosphate ABC transporter, permease protein
+sfuA	TIGR01254	ABC transporter periplasmic binding protein, thiB subfamily
+pyr_form_ly_1	TIGR01255	formate acetyltransferase
+modA	TIGR01256	molybdate ABC transporter, periplasmic molybdate-binding protein
+rim_protein	TIGR01257	rim ABC transporter
+pgm_1	TIGR01258	phosphoglycerate mutase 1 family
+comE	TIGR01259	comEA protein
+ATP_synt_c	TIGR01260	ATP synthase F0, C subunit
+hisB_Nterm	TIGR01261	histidinol-phosphatase
+maiA	TIGR01262	maleylacetoacetate isomerase
+4HPPD	TIGR01263	4-hydroxyphenylpyruvate dioxygenase
+tyr_amTase_E	TIGR01264	tyrosine aminotransferase
+tyr_nico_aTase	TIGR01265	tyrosine/nicotianamine family aminotransferase
+fum_ac_acetase	TIGR01266	fumarylacetoacetase
+Phe4hydrox_mono	TIGR01267	phenylalanine-4-hydroxylase
+Phe4hydrox_tetr	TIGR01268	phenylalanine-4-hydroxylase
+Tyr_3_monoox	TIGR01269	tyrosine 3-monooxygenase
+Trp_5_monoox	TIGR01270	tryptophan 5-monooxygenase
+CFTR_protein	TIGR01271	cystic fibrosis transmembrane conductor regulator (CFTR)
+gluP	TIGR01272	glucose/galactose transporter WARNING
+speA	TIGR01273	arginine decarboxylase
+ACC_deam	TIGR01274	1-aminocyclopropane-1-carboxylate deaminase
+ACC_deam_rel	TIGR01275	pyridoxal phosphate-dependent enzymes, D-cysteine desulfhydrase family
+thiB	TIGR01276	thiamin/thiamin pyrophosphate ABC transporter, thiamin/thiamin pyrophospate-binding protein
+thiQ	TIGR01277	thiamine ABC transporter, ATP-binding protein
+DPOR_BchB	TIGR01278	light-independent protochlorophyllide reductase, B subunit
+DPOR_bchN	TIGR01279	light-independent protochlorophyllide reductase, N subunit
+xseB	TIGR01280	exodeoxyribonuclease VII, small subunit
+DPOR_bchL	TIGR01281	light-independent protochlorophyllide reductase, iron-sulfur ATP-binding protein
+nifD	TIGR01282	nitrogenase molybdenum-iron protein alpha chain
+nifE	TIGR01283	nitrogenase MoFe cofactor biosynthesis protein NifE
+alt_nitrog_alph	TIGR01284	nitrogenase alpha chain
+nifN	TIGR01285	nitrogenase molybdenum-iron cofactor biosynthesis protein NifN
+nifK	TIGR01286	nitrogenase molybdenum-iron protein beta chain
+nifH	TIGR01287	nitrogenase iron protein
+nodI	TIGR01288	nodulation ABC transporter NodI
+LPOR	TIGR01289	light-dependent protochlorophyllide reductase
+nifB	TIGR01290	nitrogenase cofactor biosynthesis protein NifB
+nodJ	TIGR01291	ABC-2 type transporter, NodJ family
+TRX_reduct	TIGR01292	thioredoxin-disulfide reductase
+Kv_beta	TIGR01293	voltage-dependent potassium channel beta subunit
+P_lamban	TIGR01294	phospholamban
+PedC_BrcD	TIGR01295	putative bacteriocin transport accessory protein
+asd_B	TIGR01296	aspartate-semialdehyde dehydrogenase
+CDF	TIGR01297	cation diffusion facilitator family transporter
+RNaseT	TIGR01298	ribonuclease T
+synapt_SV2	TIGR01299	synaptic vesicle protein SV2
+CPA3_mnhG_phaG	TIGR01300	monovalent cation/proton antiporter, MnhG/PhaG subunit
+GPH_sucrose	TIGR01301	sucrose/H+ symporter
+IMP_dehydrog	TIGR01302	inosine-5'-monophosphate dehydrogenase
+IMP_DH_rel_1	TIGR01303	IMP dehydrogenase family protein
+IMP_DH_rel_2	TIGR01304	IMP dehydrogenase family protein
+GMP_reduct_1	TIGR01305	guanosine monophosphate reductase
+GMP_reduct_2	TIGR01306	guanosine monophosphate reductase
+pgm_bpd_ind	TIGR01307	phosphoglycerate mutase (2,3-diphosphoglycerate-independent)
+rpmD_bact	TIGR01308	ribosomal protein uL30
+uL30_arch	TIGR01309	ribosomal protein uL30
+uL30_euk	TIGR01310	60S ribosomal protein uL30
+glycerol_kin	TIGR01311	glycerol kinase
+XylB	TIGR01312	xylulokinase
+therm_gnt_kin	TIGR01313	carbohydrate kinase, thermoresistant glucokinase family
+gntK_FGGY	TIGR01314	gluconate kinase
+5C_CHO_kinase	TIGR01315	FGGY-family pentulose kinase
+gltA	TIGR01316	glutamate synthase (NADPH), homotetrameric
+GOGAT_sm_gam	TIGR01317	glutamate synthase, NADH/NADPH, small subunit
+gltD_gamma_fam	TIGR01318	glutamate synthase, small subunit
+glmL_fam	TIGR01319	conserved hypothetical protein
+mal_quin_oxido	TIGR01320	malate dehydrogenase (acceptor)
+TrpR	TIGR01321	trp operon repressor
+scrB_fam	TIGR01322	sucrose-6-phosphate hydrolase
+nitrile_alph	TIGR01323	nitrile hydratase, alpha subunit
+cysta_beta_ly_B	TIGR01324	cystathionine beta-lyase
+O_suc_HS_sulf	TIGR01325	O-succinylhomoserine sulfhydrylase
+OAH_OAS_sulfhy	TIGR01326	O-acetylhomoserine aminocarboxypropyltransferase/cysteine synthase
+PGDH	TIGR01327	phosphoglycerate dehydrogenase
+met_gam_lyase	TIGR01328	methionine gamma-lyase
+cysta_beta_ly_E	TIGR01329	cystathionine beta-lyase
+bisphos_HAL2	TIGR01330	3'(2'),5'-bisphosphate nucleotidase
+bisphos_cysQ	TIGR01331	3'(2'),5'-bisphosphate nucleotidase
+cyt_b559_alpha	TIGR01332	cytochrome b559, alpha subunit
+cyt_b559_beta	TIGR01333	cytochrome b559, beta subunit
+modD	TIGR01334	modD protein
+psaA	TIGR01335	photosystem I core protein PsaA
+psaB	TIGR01336	photosystem I core protein PsaB
+apcB	TIGR01337	allophycocyanin, beta subunit
+phycocy_alpha	TIGR01338	phycocyanin, alpha subunit
+phycocy_beta	TIGR01339	phycocyanin, beta subunit
+aconitase_mito	TIGR01340	aconitate hydratase, mitochondrial
+aconitase_1	TIGR01341	aconitate hydratase 1
+acon_putative	TIGR01342	putative aconitate hydratase
+hacA_fam	TIGR01343	homoaconitate hydratase family protein
+malate_syn_A	TIGR01344	malate synthase A
+malate_syn_G	TIGR01345	malate synthase G
+isocit_lyase	TIGR01346	isocitrate lyase
+sucB	TIGR01347	dihydrolipoyllysine-residue succinyltransferase, E2 component of oxoglutarate dehydrogenase (succinyl-transferring) complex
+PDHac_trf_long	TIGR01348	dihydrolipoyllysine-residue acetyltransferase
+PDHac_trf_mito	TIGR01349	pyruvate dehydrogenase complex dihydrolipoamide acetyltransferase
+lipoamide_DH	TIGR01350	dihydrolipoyl dehydrogenase
+adk	TIGR01351	adenylate kinase
+tonB_Cterm	TIGR01352	TonB family C-terminal domain
+dGTP_triPase	TIGR01353	putative dGTPase
+cyt_deam_tetra	TIGR01354	cytidine deaminase
+cyt_deam_dimer	TIGR01355	cytidine deaminase
+aroA	TIGR01356	3-phosphoshikimate 1-carboxyvinyltransferase
+aroB	TIGR01357	3-dehydroquinate synthase
+DAHP_synth_II	TIGR01358	3-deoxy-7-phosphoheptulonate synthase
+UMP_CMP_kin_fam	TIGR01359	UMP-CMP kinase family
+aden_kin_iso1	TIGR01360	adenylate kinase
+DAHP_synth_Bsub	TIGR01361	3-deoxy-7-phosphoheptulonate synthase
+KDO8P_synth	TIGR01362	3-deoxy-8-phosphooctulonate synthase
+strep_his_triad	TIGR01363	streptococcal histidine triad protein
+serC_1	TIGR01364	phosphoserine transaminase
+serC_2	TIGR01365	phosphoserine aminotransferase
+serC_3	TIGR01366	putative phosphoserine aminotransferase
+pyrE_Therm	TIGR01367	orotate phosphoribosyltransferase
+CPSaseIIsmall	TIGR01368	carbamoyl-phosphate synthase, small subunit
+CPSaseII_lrg	TIGR01369	carbamoyl-phosphate synthase, large subunit
+TIGR01370	TIGR01370	extracellular protein
+met_syn_B12ind	TIGR01371	5-methyltetrahydropteroyltriglutamate--homocysteine S-methyltransferase
+soxA	TIGR01372	sarcosine oxidase, alpha subunit family
+soxB	TIGR01373	sarcosine oxidase, beta subunit family
+soxD	TIGR01374	sarcosine oxidase, delta subunit family
+soxG	TIGR01375	sarcosine oxidase, gamma subunit family
+POMP_repeat	TIGR01376	chlamydial polymorphic outer membrane protein repeat
+soxA_mon	TIGR01377	sarcosine oxidase, monomeric form
+thi_PPkinase	TIGR01378	thiamine pyrophosphokinase
+thiL	TIGR01379	thiamine-phosphate kinase
+glut_syn	TIGR01380	glutathione synthase
+E1_like_apg7	TIGR01381	E1-like protein-activating enzyme Gsa7p/Apg7p
+PfpI	TIGR01382	intracellular protease, PfpI family
+not_thiJ	TIGR01383	DJ-1 family protein
+TFS_arch	TIGR01384	transcription factor S
+TFSII	TIGR01385	transcription elongation factor S-II
+cztS_silS_copS	TIGR01386	heavy metal sensor kinase
+cztR_silR_copR	TIGR01387	heavy metal response regulator
+rnd	TIGR01388	ribonuclease D
+recQ	TIGR01389	ATP-dependent DNA helicase RecQ
+CycNucDiestase	TIGR01390	2',3'-cyclic-nucleotide 2'-phosphodiesterase
+dnaG	TIGR01391	DNA primase
+homoserO_Ac_trn	TIGR01392	homoserine O-acetyltransferase
+lepA	TIGR01393	elongation factor 4
+TypA_BipA	TIGR01394	GTP-binding protein TypA/BipA
+FlgC	TIGR01395	flagellar basal-body rod protein FlgC
+FlgB	TIGR01396	flagellar basal-body rod protein FlgB
+fliM_switch	TIGR01397	flagellar motor switch protein FliM
+FlhA	TIGR01398	flagellar biosynthesis protein FlhA
+hrcV	TIGR01399	type III secretion protein, HrcV family
+fliR	TIGR01400	flagellar biosynthetic protein FliR
+fliR_like_III	TIGR01401	type III secretion apparatus protein SpaR/YscT/HrcT
+fliQ	TIGR01402	flagellar biosynthetic protein FliQ
+fliQ_rel_III	TIGR01403	type III secretion protein, HrpO family
+FlhB_rel_III	TIGR01404	type III secretion protein, YscU/HrpY family
+polC_Gram_pos	TIGR01405	DNA polymerase III, alpha subunit, Gram-positive type
+dnaQ_proteo	TIGR01406	DNA polymerase III, epsilon subunit
+dinG_rel	TIGR01407	putative DnaQ family exonuclease/DinG family helicase
+Ube1	TIGR01408	ubiquitin-activating enzyme E1
+TAT_signal_seq	TIGR01409	Tat (twin-arginine translocation) pathway signal sequence
+tatB	TIGR01410	twin arginine-targeting protein translocase TatB
+tatAE	TIGR01411	twin arginine-targeting protein translocase, TatA/E family
+tat_substr_1	TIGR01412	Tat-translocated enzyme
+Dyp_perox_fam	TIGR01413	Dyp-type peroxidase family
+autotrans_barl	TIGR01414	outer membrane autotransporter barrel domain
+trpB_rel	TIGR01415	pyridoxal-phosphate dependent TrpB-like enzyme
+Rieske_proteo	TIGR01416	ubiquinol-cytochrome c reductase, iron-sulfur subunit
+PTS_I_fam	TIGR01417	phosphoenolpyruvate-protein phosphotransferase
+PEP_synth	TIGR01418	phosphoenolpyruvate synthase
+nitro_reg_IIA	TIGR01419	PTS IIA-like nitrogen-regulatory protein PtsN
+pilT_fam	TIGR01420	twitching motility protein
+gluta_reduc_1	TIGR01421	glutathione-disulfide reductase
+phosphonatase	TIGR01422	phosphonoacetaldehyde hydrolase
+trypano_reduc	TIGR01423	trypanothione-disulfide reductase
+gluta_reduc_2	TIGR01424	glutathione-disulfide reductase
+SRP54_euk	TIGR01425	signal recognition particle protein SRP54
+MGT	TIGR01426	glycosyltransferase, MGT family
+PTS_IIC_fructo	TIGR01427	PTS system, Fru family, IIC component
+HAD_type_II	TIGR01428	haloacid dehalogenase, type II
+AMP_deaminase	TIGR01429	AMP deaminase
+aden_deam	TIGR01430	adenosine deaminase
+adm_rel	TIGR01431	adenosine deaminase-related growth factor
+QOXA	TIGR01432	cytochrome aa3 quinol oxidase, subunit II
+CyoA	TIGR01433	ubiquinol oxidase, subunit II
+glu_cys_ligase	TIGR01434	glutamate--cysteine ligase
+glu_cys_lig_rel	TIGR01435	glutamate--cysteine ligase/glutathione synthase
+glu_cys_lig_pln	TIGR01436	glutamate--cysteine ligase
+selA_rel	TIGR01437	uncharacterized pyridoxal phosphate-dependent enzyme
+TGR	TIGR01438	thioredoxin and glutathione reductase
+lp_hng_hel_AbrB	TIGR01439	transcriptional regulator, AbrB family
+TIGR01440	TIGR01440	TIGR01440 family protein
+GPR	TIGR01441	GPR endopeptidase
+SASP_gamma	TIGR01442	small, acid-soluble spore protein, gamma-type
+intein_Cterm	TIGR01443	intein C-terminal splicing region
+fkbM_fam	TIGR01444	methyltransferase, FkbM family
+intein_Nterm	TIGR01445	intein N-terminal splicing region
+DnaD_dom	TIGR01446	DnaD domain protein
+recD	TIGR01447	exodeoxyribonuclease V, alpha subunit
+recD_rel	TIGR01448	helicase, RecD/TraA family
+PGP_bact	TIGR01449	phosphoglycolate phosphatase, bacterial
+recC	TIGR01450	exodeoxyribonuclease V, gamma subunit
+B_ant_repeat	TIGR01451	conserved repeat domain
+PGP_euk	TIGR01452	phosphoglycolate/pyridoxal phosphate phosphatase family
+grpIintron_endo	TIGR01453	group I intron endonuclease
+AHBA_synth_RP	TIGR01454	AHBA synthesis associated protein
+glmM	TIGR01455	phosphoglucosamine mutase
+CECR5	TIGR01456	HAD hydrolase, TIGR01456 family
+HAD-SF-IIA-hyp2	TIGR01457	HAD hydrolase, TIGR01457 family
+HAD-SF-IIA-hyp3	TIGR01458	HAD hydrolase, TIGR01458 family
+HAD-SF-IIA-hyp4	TIGR01459	HAD hydrolase, TIGR01459 family
+HAD-SF-IIA	TIGR01460	HAD hydrolase, family IIA
+greB	TIGR01461	transcription elongation factor GreB
+greA	TIGR01462	transcription elongation factor GreA
+mtaA_cmuA	TIGR01463	methyltransferase, MtaA/CmuA family
+hemE	TIGR01464	uroporphyrinogen decarboxylase
+cobM_cbiF	TIGR01465	precorrin-4 C11-methyltransferase
+cobJ_cbiH	TIGR01466	precorrin-3B C17-methyltransferase
+cobI_cbiL	TIGR01467	precorrin-2 C(20)-methyltransferase
+cobA_cysG_Cterm	TIGR01469	uroporphyrinogen-III C-methyltransferase
+cysG_Nterm	TIGR01470	siroheme synthase, N-terminal domain
+gmd	TIGR01472	GDP-mannose 4,6-dehydratase
+cyoE_ctaB	TIGR01473	protoheme IX farnesyltransferase
+ubiA_proteo	TIGR01474	4-hydroxybenzoate polyprenyl transferase
+ubiA_other	TIGR01475	putative 4-hydroxybenzoate polyprenyltransferase
+chlor_syn_BchG	TIGR01476	bacteriochlorophyll/chlorophyll synthetase
+RIFIN	TIGR01477	variant surface antigen, rifin family
+STEVOR	TIGR01478	variant surface antigen, stevor family
+GMP_PMI	TIGR01479	mannose-1-phosphate guanylyltransferase/mannose-6-phosphate isomerase
+copper_res_A	TIGR01480	copper-resistance protein, CopA family
+ccpA	TIGR01481	catabolite control protein A
+SPP-subfamily	TIGR01482	sucrose-phosphate phosphatase subfamily
+HAD-SF-IIB	TIGR01484	HAD hydrolase, family IIB
+SPP_plant-cyano	TIGR01485	sucrose phosphatase
+HAD-SF-IIB-MPGP	TIGR01486	mannosyl-3-phosphoglycerate phosphatase family
+Pglycolate_arch	TIGR01487	phosphoglycolate phosphatase, TA0175-type
+HAD-SF-IB	TIGR01488	HAD phosphoserine phosphatase-like hydrolase, family IB
+DKMTPPase-SF	TIGR01489	2,3-diketo-5-methylthio-1-phosphopentane phosphatase
+HAD-SF-IB-hyp1	TIGR01490	HAD hydrolase, family IB
+HAD-SF-IB-PSPlk	TIGR01491	phosphoserine phosphatase-like hydrolase, archaeal
+CPW_WPC	TIGR01492	Plasmodium falciparum CPW-WPC domain
+HAD-SF-IA-v2	TIGR01493	HAD hydrolase, family IA, variant 2
+ATPase_P-type	TIGR01494	HAD ATPase, P-type, family IC
+ETRAMP	TIGR01495	early transcribed membrane protein (ETRAMP) family
+DHPS	TIGR01496	dihydropteroate synthase
+kdpB	TIGR01497	K+-transporting ATPase, B subunit
+folK	TIGR01498	2-amino-4-hydroxy-6-hydroxymethyldihydropteridine diphosphokinase
+folC	TIGR01499	bifunctional protein FolC
+sepiapter_red	TIGR01500	sepiapterin reductase
+MthylAspMutase	TIGR01501	methylaspartate mutase, S subunit
+B_methylAsp_ase	TIGR01502	methylaspartate ammonia-lyase
+MthylAspMut_E	TIGR01503	methylaspartate mutase, E subunit
+glyox_carbo_lig	TIGR01504	glyoxylate carboligase
+tartro_sem_red	TIGR01505	2-hydroxy-3-oxopropionate reductase
+ribC_arch	TIGR01506	riboflavin synthase
+hopene_cyclase	TIGR01507	squalene-hopene cyclase
+rib_reduct_arch	TIGR01508	diaminohydroxyphosphoribosylaminopyrimidine reductase
+HAD-SF-IA-v3	TIGR01509	HAD hydrolase, family IA, variant 3
+coaD_prev_kdtB	TIGR01510	pantetheine-phosphate adenylyltransferase
+ATPase-IB1_Cu	TIGR01511	copper-translocating P-type ATPase
+ATPase-IB2_Cd	TIGR01512	cadmium-translocating P-type ATPase
+NAPRTase_put	TIGR01513	nicotinate phosphoribosyltransferase
+NAPRTase	TIGR01514	nicotinate phosphoribosyltransferase
+branching_enzym	TIGR01515	1,4-alpha-glucan branching enzyme
+ATPase-IIB_Ca	TIGR01517	calcium-translocating P-type ATPase, PMCA-type
+g3p_cytidyltrns	TIGR01518	glycerol-3-phosphate cytidylyltransferase
+plasmod_dom_1	TIGR01519	Plasmodium falciparum uncharacterized domain
+FruBisAldo_II_A	TIGR01520	fructose-bisphosphate aldolase, class II
+FruBisAldo_II_B	TIGR01521	fructose-bisphosphate aldolase, class II, Calvin cycle subtype
+ATPase-IIA2_Ca	TIGR01522	calcium-transporting P-type ATPase, PMR1-type
+ATPase-IID_K-Na	TIGR01523	potassium/sodium efflux P-type ATPase, fungal-type
+ATPase-IIIB_Mg	TIGR01524	magnesium-translocating P-type ATPase
+ATPase-IB_hvy	TIGR01525	heavy metal translocating P-type ATPase
+nadR_NMN_Atrans	TIGR01526	nicotinamide-nucleotide adenylyltransferase
+arch_NMN_Atrans	TIGR01527	nicotinamide-nucleotide adenylyltransferase
+NMN_trans_PnuC	TIGR01528	nicotinamide mononucleotide transporter PnuC
+argR_whole	TIGR01529	arginine repressor
+nadN	TIGR01530	NAD nucleotidase
+glyc_debranch	TIGR01531	glycogen debranching enzyme
+E4PD_g-proteo	TIGR01532	erythrose-4-phosphate dehydrogenase
+lipo_e_P4	TIGR01533	5'-nucleotidase, lipoprotein e(P4) family
+GAPDH-I	TIGR01534	glyceraldehyde-3-phosphate dehydrogenase, type I
+glucan_glucosid	TIGR01535	glucan 1,4-alpha-glucosidase
+asn_synth_AEB	TIGR01536	asparagine synthase (glutamine-hydrolyzing)
+portal_HK97	TIGR01537	phage portal protein, HK97 family
+portal_SPP1	TIGR01538	phage portal protein, SPP1 family
+portal_lambda	TIGR01539	phage portal protein, lambda family
+portal_PBSX	TIGR01540	phage portal protein, PBSX family
+tape_meas_lam_C	TIGR01541	phage tail tape measure protein, lambda family
+A118_put_portal	TIGR01542	phage portal protein, putative, A118 family
+proheadase_HK97	TIGR01543	phage prohead protease, HK97 family
+HAD-SF-IE	TIGR01544	HAD hydrolase, family IE
+YfhB_g-proteo	TIGR01545	HAD hydrolase, family IF
+GAPDH-II_archae	TIGR01546	glyceraldehyde-3-phosphate dehydrogenase, type II
+phage_term_2	TIGR01547	phage terminase, large subunit, PBSX family
+HAD-SF-IA-hyp1	TIGR01548	HAD hydrolase, TIGR01548 family
+HAD-SF-IA-v1	TIGR01549	HAD hydrolase, family IA, variant 1
+DOC_P1	TIGR01550	death-on-curing family protein
+major_capsid_P2	TIGR01551	phage major capsid protein, P2 family
+phd_fam	TIGR01552	prevent-host-death family protein
+formate-DH-alph	TIGR01553	formate dehydrogenase-N alpha subunit
+major_cap_HK97	TIGR01554	phage major capsid protein, HK97 family
+phge_rel_HI1409	TIGR01555	phage-associated protein, HI1409 family
+rhamnosyltran	TIGR01556	rhamnosyltransferase
+myb_SHAQKYF	TIGR01557	myb-like DNA-binding domain, SHAQKYF class
+sm_term_P27	TIGR01558	putative phage terminase, small subunit, P27 family
+squal_synth	TIGR01559	farnesyl-diphosphate farnesyltransferase
+put_DNA_pack	TIGR01560	uncharacterized phage protein (possible DNA packaging)
+gde_arch	TIGR01561	putative glycogen debranching enzyme, archaeal type
+FdhE	TIGR01562	formate dehydrogenase accessory protein FdhE
+gp16_SPP1	TIGR01563	putative phage head-tail adaptor
+S_layer_MJ	TIGR01564	S-layer protein
+homeo_ZF_HD	TIGR01565	homeobox domain, ZF-HD class
+ZF_HD_prot_N	TIGR01566	ZF-HD homeobox protein Cys/His-rich dimerization domain
+S_layer_rel_Mac	TIGR01567	S-layer family duplication domain
+A_thal_3678	TIGR01568	uncharacterized plant-specific domain TIGR01568
+A_tha_TIGR01569	TIGR01569	plant integral membrane protein TIGR01569
+A_thal_3588	TIGR01570	uncharacterized plant-specific domain TIGR01570
+A_thal_Cys_rich	TIGR01571	uncharacterized Cys-rich domain
+A_thl_para_3677	TIGR01572	Arabidopsis paralogous family TIGR01572
+cas2	TIGR01573	CRISPR-associated endonuclease Cas2
+miaB-methiolase	TIGR01574	tRNA-i(6)A37 thiotransferase enzyme MiaB
+rimI	TIGR01575	ribosomal-protein-alanine acetyltransferase
+oligosac_amyl	TIGR01577	oligosaccharide amylase
+MiaB-like-B	TIGR01578	MiaB-like tRNA modifying enzyme, archaeal-type
+MiaB-like-C	TIGR01579	MiaB-like tRNA modifying enzyme
+narG	TIGR01580	nitrate reductase, alpha subunit
+Mo_ABC_porter	TIGR01581	NifC-like ABC-type porter
+FDH-beta	TIGR01582	formate dehydrogenase, beta subunit
+formate-DH-gamm	TIGR01583	formate dehydrogenase, gamma subunit
+citF	TIGR01584	citrate lyase, alpha subunit
+yopT_cys_prot	TIGR01586	cysteine protease domain, YopT-type
+cas3_core	TIGR01587	CRISPR-associated helicase Cas3
+citE	TIGR01588	citrate (pro-3S)-lyase, beta subunit
+A_thal_3526	TIGR01589	uncharacterized plant-specific domain TIGR01589
+yir-bir-cir_Pla	TIGR01590	yir/bir/cir-family of variant antigens
+Fdh-alpha	TIGR01591	formate dehydrogenase, alpha subunit
+holin_SPP1	TIGR01592	holin, SPP1 family
+holin_tox_secr	TIGR01593	toxin secretion/phage lysis holin
+holin_lambda	TIGR01594	phage holin, lambda family
+cas_CT1132	TIGR01595	CRISPR-associated protein, CT1132 family
+cas3_HD	TIGR01596	CRISPR-associated endonuclease Cas3-HD
+PYST-B	TIGR01597	Plasmodium yoelii subtelomeric family PYST-B
+holin_phiLC3	TIGR01598	holin, phage phi LC3 family
+PYST-A	TIGR01599	Plasmodium yoelii subtelomeric family PYST-A
+phage_tail_L	TIGR01600	phage minor tail protein L
+PYST-C1	TIGR01601	Plasmodium yoelii subtelomeric domain PYST-C1
+PY-rept-46	TIGR01602	Plasmodium yoelii repeat of length 46
+maj_tail_phi13	TIGR01603	phage major tail protein, phi13 family
+PYST-C2	TIGR01604	Plasmodium yoelii subtelomeric domain PYST-C2
+PYST-D	TIGR01605	Plasmodium yoelii subtelomeric family PYST-D
+holin_BlyA	TIGR01606	holin, BlyA family
+PST-A	TIGR01607	Plasmodium subtelomeric family
+citD	TIGR01608	citrate lyase acyl carrier protein
+PF_unchar_267	TIGR01609	Plasmodium falciparum uncharacterized protein TIGR01609
+phage_O_Nterm	TIGR01610	phage replication protein O, N-terminal domain
+tail_tube	TIGR01611	phage major tail tube protein
+235kDa-fam	TIGR01612	rhoptry protein
+primase_Cterm	TIGR01613	phage/plasmid primase, P4 family, C-terminal domain
+PME_inhib	TIGR01614	pectinesterase inhibitor domain
+A_thal_3542	TIGR01615	uncharacterized plant-specific domain TIGR01615
+nitro_assoc	TIGR01616	nitrogenase-associated protein
+arsC_related	TIGR01617	transcriptional regulator, Spx/MgsR family
+phage_P_loop	TIGR01618	phage nucleotide-binding protein
+hyp_HI0040	TIGR01619	TIGR01619 family protein
+hyp_HI0043	TIGR01620	TIGR01620 family protein
+RluA-like	TIGR01621	pseudouridine synthase Rlu family protein, TIGR01621
+SF-CC1	TIGR01622	splicing factor, CC1-like family
+put_zinc_LRP1	TIGR01623	putative zinc finger domain, LRP1 type
+LRP1_Cterm	TIGR01624	LRP1 C-terminal domain
+YidE_YbjL_dupl	TIGR01625	AspT/YidE/YbjL antiporter duplication domain
+ytfJ_HI0045	TIGR01626	conserved hypothetical protein YtfJ-family, TIGR01626
+A_thal_3515	TIGR01627	uncharacterized plant-specific domain TIGR01627
+PABP-1234	TIGR01628	polyadenylate binding protein, human types 1, 2, 3, 4 family
+rep_II_X	TIGR01629	phage/plasmid replication protein, gene II/X family
+psiM2_ORF9	TIGR01630	phage uncharacterized protein, C-terminal domain
+Trypano_RHS	TIGR01631	trypanosome RHS family
+L11_bact	TIGR01632	ribosomal protein uL11
+phi3626_gp14_N	TIGR01633	putative phage tail component, N-terminal domain
+tail_P2_I	TIGR01634	phage tail protein I
+tail_comp_S	TIGR01635	phage virion morphogenesis protein
+phage_rinA	TIGR01636	phage transcriptional regulator, RinA family
+phage_arpU	TIGR01637	phage transcriptional regulator, ArpU family
+Atha_cystat_rel	TIGR01638	Arabidopsis thaliana cystatin-related protein
+P_fal_TIGR01639	TIGR01639	Plasmodium falciparum uncharacterized domain TIGR01639
+F_box_assoc_1	TIGR01640	F-box protein interaction domain
+phageSPP1_gp7	TIGR01641	phage head morphogenesis protein, SPP1 gp7 family
+U2AF_lg	TIGR01642	U2 snRNP auxilliary factor, large subunit, splicing factor
+YD_repeat_2x	TIGR01643	YD repeat (two copies)
+phage_P2_V	TIGR01644	phage baseplate assembly protein V
+half-pint	TIGR01645	poly-U binding splicing factor, half-pint family
+vgr_GE	TIGR01646	Rhs element Vgr protein
+ATPase-IIIA_H	TIGR01647	plasma-membrane proton-efflux P-type ATPase
+hnRNP-R-Q	TIGR01648	hnRNP-R, Q splicing factor family
+hnRNP-L_PTB	TIGR01649	hnRNP-L/PTB/hephaestus splicing factor family
+PD_CobS	TIGR01650	cobaltochelatase, CobS subunit
+CobT	TIGR01651	cobaltochelatase, CobT subunit
+ATPase-Plipid	TIGR01652	phospholipid-translocating P-type ATPase, flippase
+lactococcin_972	TIGR01653	bacteriocin, lactococcin 972 family
+bact_immun_7tm	TIGR01654	bacteriocin-associated integral membrane protein
+yxeA_fam	TIGR01655	conserved hypothetical protein
+Histidinol-ppas	TIGR01656	histidinol-phosphate phosphatase domain
+P-ATPase-V	TIGR01657	P-type ATPase of unknown pump specificity (type V)
+EYA-cons_domain	TIGR01658	EYA conserved domain
+sex-lethal	TIGR01659	sex-lethal family splicing factor
+narH	TIGR01660	nitrate reductase, beta subunit
+ELAV_HUD_SF	TIGR01661	ELAV/HuD family splicing factor
+HAD-SF-IIIA	TIGR01662	HAD hydrolase, family IIIA
+PNK-3'Pase	TIGR01663	polynucleotide kinase 3'-phosphatase
+DNA-3'-Pase	TIGR01664	DNA 3'-phosphatase
+put_anti_recept	TIGR01665	phage minor structural protein, N-terminal region
+YCCS	TIGR01666	TIGR01666 family membrane protein
+YCCS_YHJK	TIGR01667	integral membrane protein, YccS/YhfK family
+YqeG_hyp_ppase	TIGR01668	HAD phosphatase, family IIIA
+phage_XkdX	TIGR01669	phage uncharacterized protein, XkdX family
+KdsC-phosphatas	TIGR01670	3-deoxy-D-manno-octulosonate 8-phosphate phosphatase, YrbI family
+phage_TIGR01671	TIGR01671	phage conserved hypothetical protein TIGR01671
+AphA	TIGR01672	HAD phosphatase, family IIIB
+holin_LLH	TIGR01673	phage holin, LL-H family
+phage_lambda_G	TIGR01674	phage minor tail protein G
+plant-AP	TIGR01675	plant acid phosphatase
+GLDHase	TIGR01676	galactonolactone dehydrogenase
+pln_FAD_oxido	TIGR01677	plant-specific FAD-dependent oxidoreductase
+FAD_lactone_ox	TIGR01678	sugar 1,4-lactone oxidases
+bact_FAD_ox	TIGR01679	FAD-linked oxidoreductase
+Veg_Stor_Prot	TIGR01680	vegetative storage protein
+HAD-SF-IIIC	TIGR01681	HAD phosphatase, family IIIC
+moaD	TIGR01682	molybdopterin converting factor, subunit 1
+thiS	TIGR01683	thiamine biosynthesis protein ThiS
+viral_ppase	TIGR01684	viral phosphatase
+MDP-1	TIGR01685	magnesium-dependent phosphatase-1
+FkbH	TIGR01686	FkbH domain
+moaD_arch	TIGR01687	MoaD family protein
+dltC	TIGR01688	D-alanine--poly(phosphoribitol) ligase, subunit 2
+EcbF-BcbF	TIGR01689	capsule biosynthesis phosphatase
+ICE_RAQPRD	TIGR01690	integrative conjugative element protein, RAQPRD family
+enolase-ppase	TIGR01691	2,3-diketo-5-methylthio-1-phosphopentane phosphatase
+HIBADH	TIGR01692	3-hydroxyisobutyrate dehydrogenase
+UTase_glnD	TIGR01693	protein-P-II uridylyltransferase
+MTAP	TIGR01694	methylthioadenosine phosphorylase
+murJ_mviN	TIGR01695	murein biosynthesis integral membrane protein MurJ
+deoB	TIGR01696	phosphopentomutase
+PNPH-PUNA-XAPA	TIGR01697	inosine/guanosine/xanthosine phosphorylase family
+PUNP	TIGR01698	purine nucleotide phosphorylase
+XAPA	TIGR01699	xanthosine phosphorylase
+PNPH	TIGR01700	purine nucleoside phosphorylase I, inosine and guanosine-specific
+Fdhalpha-like	TIGR01701	oxidoreductase alpha (molybdopterin) subunit
+CO_DH_cata	TIGR01702	carbon-monoxide dehydrogenase, catalytic subunit
+hybrid_clust	TIGR01703	hydroxylamine reductase
+MTA/SAH-Nsdase	TIGR01704	MTA/SAH nucleosidase
+MTA/SAH-nuc-hyp	TIGR01705	putative 5'-methylthioadenosine/S-adenosylhomocysteine nucleosidase
+NAPA	TIGR01706	periplasmic nitrate reductase, large subunit
+gspI	TIGR01707	type II secretion system protein I
+typeII_sec_gspH	TIGR01708	type II secretion system protein H
+typeII_sec_gspL	TIGR01709	type II secretion system protein L
+typeII_sec_gspG	TIGR01710	type II secretion system protein G
+gspJ	TIGR01711	type II secretion system protein J
+phage_N6A_met	TIGR01712	phage N-6-adenine-methyltransferase
+typeII_sec_gspC	TIGR01713	type II secretion system protein C
+phage_rep_org_N	TIGR01714	phage replisome organizer, putative, N-terminal region
+phage_lam_T	TIGR01715	phage tail assembly protein T
+RGG_Cterm	TIGR01716	transcriptional activator, Rgg/GadR/MutR family, C-terminal domain
+AMP-nucleosdse	TIGR01717	AMP nucleosidase
+Uridine-psphlse	TIGR01718	uridine phosphorylase
+euk_UDPppase	TIGR01719	uridine phosphorylase
+NRPS-para261	TIGR01720	non-ribosomal peptide synthase domain TIGR01720
+AMN-like	TIGR01721	putative AMP nucleosidase
+MMSDH	TIGR01722	methylmalonate-semialdehyde dehydrogenase (acylating)
+hmd_TIGR	TIGR01723	5,10-methenyltetrahydromethanopterin hydrogenase
+hmd_rel	TIGR01724	H2-forming N(5),N(10)-methenyltetrahydromethanopterin dehydrogenase-related protein
+phge_HK97_gp10	TIGR01725	phage protein, HK97 gp10 family
+HEQRo_perm_3TM	TIGR01726	amino ABC transporter, permease protein, 3-TM region, His/Glu/Gln/Arg/opine family
+oligo_HPY	TIGR01727	oligopeptide/dipeptide ABC transporter, ATP-binding protein, C-terminal domain
+SsuA_fam	TIGR01728	ABC transporter, substrate-binding protein, aliphatic sulfonates family
+taurine_ABC_bnd	TIGR01729	taurine ABC transporter, periplasmic binding protein
+RND_mfp	TIGR01730	efflux transporter, RND family, MFP subunit
+fil_hemag_20aa	TIGR01731	adhesin HecA family 20-residue repeat (two copies)
+tiny_TM_bacill	TIGR01732	conserved hypothetical protein
+AA-adenyl-dom	TIGR01733	amino acid adenylation domain
+D-ala-DACP-lig	TIGR01734	D-alanine--poly(phosphoribitol) ligase, subunit 1
+FGAM_synt	TIGR01735	phosphoribosylformylglycinamidine synthase
+FGAM_synth_II	TIGR01736	phosphoribosylformylglycinamidine synthase II
+FGAM_synth_I	TIGR01737	phosphoribosylformylglycinamidine synthase I
+bioH	TIGR01738	pimelyl-[acyl-carrier protein] methyl ester esterase
+tegu_FGAM_synt	TIGR01739	herpesvirus tegument protein/v-FGAM-synthase
+pyrF	TIGR01740	orotidine 5'-phosphate decarboxylase
+staph_tand_hypo	TIGR01741	conserved hypothetical protein
+SA_tandem_lipo	TIGR01742	Staphylococcus tandem lipoproteins
+purR_Bsub	TIGR01743	pur operon repressor PurR
+XPRTase	TIGR01744	xanthine phosphoribosyltransferase
+asd_gamma	TIGR01745	aspartate-semialdehyde dehydrogenase
+Thioester-redct	TIGR01746	thioester reductase domain
+diampropi_NH3ly	TIGR01747	diaminopropionate ammonia-lyase family
+rhaA	TIGR01748	L-rhamnose isomerase
+fabA	TIGR01749	beta-hydroxyacyl-(acyl-carrier-protein) dehydratase FabA
+fabZ	TIGR01750	beta-hydroxyacyl-(acyl-carrier-protein) dehydratase FabZ
+crot-CoA-red	TIGR01751	crotonyl-CoA carboxylase/reductase
+flav_long	TIGR01752	flavodoxin
+flav_short	TIGR01753	flavodoxin
+flav_RNR	TIGR01754	putative ribonucleotide reductase-associated flavodoxin
+flav_wrbA	TIGR01755	NAD(P)H:quinone oxidoreductase, type IV
+LDH_protist	TIGR01756	lactate dehydrogenase
+Malate-DH_plant	TIGR01757	malate dehydrogenase, NADP-dependent
+MDH_euk_cyt	TIGR01758	malate dehydrogenase, NAD-dependent
+MalateDH-SF1	TIGR01759	malate dehydrogenase
+tape_meas_TP901	TIGR01760	phage tail tape measure protein, TP901 family, core region
+thiaz-red	TIGR01761	thiazolinyl imide reductase
+chlorin-enz	TIGR01762	chlorinating enzyme
+MalateDH_bact	TIGR01763	malate dehydrogenase, NAD-dependent
+excise	TIGR01764	DNA binding domain, excisionase family
+tspaseT_teng_N	TIGR01765	transposase, putative, N-terminal domain
+tspaseT_teng_C	TIGR01766	transposase, IS605 OrfB family
+MTRK	TIGR01767	S-methyl-5-thioribose kinase
+GGGP-family	TIGR01768	geranylgeranylglyceryl phosphate synthase family protein
+GGGP	TIGR01769	phosphoglycerol geranylgeranyltransferase
+NDH_I_N	TIGR01770	proton-translocating NADH-quinone oxidoreductase, chain N
+L-LDH-NAD	TIGR01771	L-lactate dehydrogenase
+MDH_euk_gproteo	TIGR01772	malate dehydrogenase, NAD-dependent
+GABAperm	TIGR01773	GABA permease
+PFL2-3	TIGR01774	glycyl radical enzyme, PFL2/glycerol dehydratase family
+TonB-tbp-lbp	TIGR01776	TonB-dependent lactoferrin and transferrin receptors
+yfcH	TIGR01777	TIGR01777 family protein
+TonB-copper	TIGR01778	TonB-dependent copper receptor
+TonB-B12	TIGR01779	TonB-dependent vitamin B12 receptor
+SSADH	TIGR01780	succinate-semialdehyde dehydrogenase
+Trep_dent_lipo	TIGR01781	Treponema denticola clustered lipoprotein
+TonB-Xanth-Caul	TIGR01782	TonB-dependent receptor
+TonB-siderophor	TIGR01783	TonB-dependent siderophore receptor
+T_den_put_tspse	TIGR01784	conserved hypothetical protein
+TonB-hemin	TIGR01785	TonB-dependent heme/hemoglobin receptor family protein
+TonB-hemlactrns	TIGR01786	TonB-dependent hemoglobin/transferrin/lactoferrin receptor family protein
+squalene_cyclas	TIGR01787	squalene/oxidosqualene cyclases
+Glu-decarb-GAD	TIGR01788	glutamate decarboxylase
+lycopene_cycl	TIGR01789	lycopene cyclase
+carotene-cycl	TIGR01790	lycopene cyclase family protein
+CM_archaeal	TIGR01791	chorismate mutase
+urease_alph	TIGR01792	urease, alpha subunit
+cit_synth_euk	TIGR01793	citrate (Si)-synthase, eukaryotic
+CM_mono_cladeE	TIGR01795	chorismate mutase
+CM_mono_aroH	TIGR01796	chorismate mutase
+CM_P_1	TIGR01797	chorismate mutase
+cit_synth_I	TIGR01798	citrate (Si)-synthase
+CM_T	TIGR01799	chorismate mutase
+cit_synth_II	TIGR01800	2-methylcitrate synthase/citrate synthase II
+CM_A	TIGR01801	chorismate mutase
+CM_pl-yst	TIGR01802	chorismate mutase
+CM-like	TIGR01803	chorismate mutase related enzymes
+BADH	TIGR01804	betaine-aldehyde dehydrogenase
+CM_mono_grmpos	TIGR01805	chorismate mutase
+CM_mono2	TIGR01806	putative chorismate mutase
+CM_P2	TIGR01807	chorismate mutase
+CM_M_hiGC-arch	TIGR01808	chorismate mutase
+Shik-DH-AROM	TIGR01809	shikimate-5-dehydrogenase
+betA	TIGR01810	choline dehydrogenase
+sdhA_Bsu	TIGR01811	succinate dehydrogenase or fumarate reductase, flavoprotein subunit
+sdhA_frdA_Gneg	TIGR01812	succinate dehydrogenase or fumarate reductase, flavoprotein subunit
+flavo_cyto_c	TIGR01813	flavocytochrome c
+kynureninase	TIGR01814	kynureninase
+TrpE-clade3	TIGR01815	anthranilate synthase
+sdhA_forward	TIGR01816	succinate dehydrogenase, flavoprotein subunit
+nifA	TIGR01817	Nif-specific regulatory protein
+ntrC	TIGR01818	nitrogen regulation protein NR(I)
+F420_cofD	TIGR01819	2-phospho-L-lactate transferase
+TrpE-arch	TIGR01820	anthranilate synthase component I
+5aminolev_synth	TIGR01821	5-aminolevulinic acid synthase
+2am3keto_CoA	TIGR01822	glycine C-acetyltransferase
+PabB-fungal	TIGR01823	aminodeoxychorismate synthase
+PabB-clade2	TIGR01824	aminodeoxychorismate synthase, component I
+gly_Cac_T_rel	TIGR01825	putative pyridoxal phosphate-dependent acyltransferase
+CofD_related	TIGR01826	conserved hypothetical protein
+gatC_rel	TIGR01827	putative Asp-tRNA(Asn)/Glu-tRNA(Gln) amidotransferase, subunit C
+pyru_phos_dikin	TIGR01828	pyruvate, phosphate dikinase
+AcAcCoA_reduct	TIGR01829	acetoacetyl-CoA reductase
+3oxo_ACP_reduc	TIGR01830	3-oxoacyl-[acyl-carrier-protein] reductase
+fabG_rel	TIGR01831	putative 3-oxoacyl-(acyl-carrier-protein) reductase
+kduD	TIGR01832	2-deoxy-D-gluconate 3-dehydrogenase
+HMG-CoA-S_euk	TIGR01833	hydroxymethylglutaryl-CoA synthase
+PHA_synth_III_E	TIGR01834	poly(R)-hydroxyalkanoic acid synthase, class III, PhaE subunit
+HMG-CoA-S_prok	TIGR01835	hydroxymethylglutaryl-CoA synthase
+PHA_synth_III_C	TIGR01836	poly(R)-hydroxyalkanoic acid synthase, class III, PhaC subunit
+PHA_granule_1	TIGR01837	poly(hydroxyalkanoate) granule-associated protein
+PHA_synth_I	TIGR01838	poly(R)-hydroxyalkanoic acid synthase, class I
+PHA_synth_II	TIGR01839	poly(R)-hydroxyalkanoic acid synthase, class II
+esterase_phb	TIGR01840	esterase, PHB depolymerase family
+phasin	TIGR01841	phasin family protein
+type_I_sec_PrtD	TIGR01842	type I secretion system ATPase
+type_I_hlyD	TIGR01843	type I secretion membrane fusion protein, HlyD family
+type_I_sec_TolC	TIGR01844	type I secretion outer membrane protein, TolC family
+outer_NodT	TIGR01845	efflux transporter, outer membrane factor (OMF) lipoprotein, NodT family
+type_I_sec_HlyB	TIGR01846	type I secretion system ATPase
+bacteriocin_sig	TIGR01847	bacteriocin-type signal sequence
+PHA_reg_PhaR	TIGR01848	polyhydroxyalkanoate synthesis repressor PhaR
+PHB_depoly_PhaZ	TIGR01849	polyhydroxyalkanoate depolymerase, intracellular
+argC	TIGR01850	N-acetyl-gamma-glutamyl-phosphate reductase
+argC_other	TIGR01851	N-acetyl-gamma-glutamyl-phosphate reductase
+lipid_A_lpxA	TIGR01852	acyl-[acyl-carrier-protein]-UDP-N-acetylglucosamine O-acyltransferase
+lipid_A_lpxD	TIGR01853	UDP-3-O-[3-hydroxymyristoyl] glucosamine N-acyltransferase LpxD
+lipid_A_lpxH	TIGR01854	UDP-2,3-diacylglucosamine diphosphatase
+IMP_synth_hisH	TIGR01855	imidazole glycerol phosphate synthase, glutamine amidotransferase subunit
+hisJ_fam	TIGR01856	histidinol phosphate phosphatase, HisJ family
+FGAM-synthase	TIGR01857	phosphoribosylformylglycinamidine synthase
+tag_bisphos_ald	TIGR01858	class II aldolase, tagatose bisphosphate family
+fruc_bis_ald_	TIGR01859	fructose-1,6-bisphosphate aldolase, class II
+VNFD	TIGR01860	nitrogenase vanadium-iron protein, alpha chain
+ANFD	TIGR01861	nitrogenase iron-iron protein, alpha chain
+N2-ase-Ialpha	TIGR01862	nitrogenase component I, alpha chain
+cas_Csd1	TIGR01863	CRISPR-associated protein Cas8c/Csd1, subtype I-C/DVULG
+cas_Csn1	TIGR01865	CRISPR subtype II RNA-guided endonuclease Cas9
+cas_Csn2	TIGR01866	CRISPR type II-A/NMEMI-associated protein Csn2
+casD_Cas5e	TIGR01868	CRISPR-associated protein Cas5/CasD, subtype I-E/ECOLI
+casC_Cse4	TIGR01869	CRISPR-associated protein Cas7/Cse4/CasC, subtype I-E/ECOLI
+cas_TM1810_Csm2	TIGR01870	CRISPR type III-A/MTUBE-associated protein Csm2
+cas_CT1978	TIGR01873	CRISPR-associated endoribonuclease Cas2, subtype I-E/ECOLI
+cas_cas5a	TIGR01874	CRISPR-associated protein Cas5, subtype I-A/APERN
+cas_MJ0381	TIGR01875	CRISPR-associated autoregulator DevR family
+cas_Cas5d	TIGR01876	CRISPR-associated protein Cas5, subtype I-C/DVULG
+cas_cas6	TIGR01877	CRISPR-associated endoribonuclease Cas6
+cas_Csa5	TIGR01878	CRISPR type I-A/APERN-associated protein Csa5
+hydantase	TIGR01879	amidase, hydantoinase/carbamoylase family
+Ac-peptdase-euk	TIGR01880	N-acyl-L-amino-acid amidohydrolase
+cas_Cmr5	TIGR01881	CRISPR type III-B/RAMP module-associated protein Cmr5
+peptidase-T	TIGR01882	peptidase T
+PepT-like	TIGR01883	peptidase T-like protein
+cas_HTH	TIGR01884	CRISPR locus-related DNA-binding protein
+Orn_aminotrans	TIGR01885	ornithine--oxo-acid transaminase
+dipeptidase	TIGR01886	dipeptidase PepV
+dipeptidaselike	TIGR01887	putative dipeptidase
+cas_cmr3	TIGR01888	CRISPR type III-B/RAMP module-associated protein Cmr3
+Staph_reg_Sar	TIGR01889	staphylococcal accessory regulator family
+N-Ac-Glu-synth	TIGR01890	amino-acid N-acetyltransferase
+amidohydrolases	TIGR01891	amidohydrolase
+AcOrn-deacetyl	TIGR01892	acetylornithine deacetylase (ArgE)
+aa-his-dipept	TIGR01893	Xaa-His dipeptidase
+cas_TM1795_cmr1	TIGR01894	CRISPR type III-B/RAMP module RAMP protein Cmr1
+cas_Cas5t	TIGR01895	CRISPR-associated protein Cas5, subtype I-B/TNEAP
+cas_AF1879	TIGR01896	CRISPR-associated protein Cas4/Csa1, subtype I-A/APERN
+cas_MJ1666	TIGR01897	CRISPR-associated protein, MJ1666 family
+cas_TM1791_cmr6	TIGR01898	CRISPR type III-B/RAMP module RAMP protein Cmr6
+cas_TM1807_csm5	TIGR01899	CRISPR type III-A/MTUBE-associated RAMP protein Csm5
+dapE-gram_pos	TIGR01900	succinyl-diaminopimelate desuccinylase
+adhes_NPXG	TIGR01901	filamentous hemagglutinin family N-terminal domain
+dapE-lys-deAc	TIGR01902	N-acetyl-ornithine/N-acetyl-lysine deacetylase
+cas5_csm4	TIGR01903	CRISPR type III-A/MTUBE-associated RAMP protein Csm4
+GSu_C4xC__C2xCH	TIGR01904	Geobacter sulfurreducens CxxxxCH...CXXCH domain
+paired_CXXCH_1	TIGR01905	doubled CXXCH domain
+integ_TIGR01906	TIGR01906	integral membrane protein TIGR01906
+casE_Cse3	TIGR01907	CRISPR-associated protein Cas6/Cse3/CasE, subtype I-E/ECOLI
+cas_CXXC_CXXC	TIGR01908	CRISPR-associated protein Cas8b1/Cst1, subtype I-B/TNEAP
+C_GCAxxG_C_C	TIGR01909	C_GCAxxG_C_C family protein
+DapE-ArgE	TIGR01910	peptidase, ArgE/DapE family
+HesB_rel_seleno	TIGR01911	HesB-like selenoprotein
+TatC-Arch	TIGR01912	Sec-independent protein translocase TatC
+bet_lambda	TIGR01913	phage recombination protein Bet
+cas_Csa4	TIGR01914	CRISPR-associated protein Cas8a2/Csa4, subtype I-A/APERN
+npdG	TIGR01915	NADPH-dependent F420 reductase
+F420_cofE	TIGR01916	coenzyme F420-0:L-glutamate ligase
+gly_red_sel_B	TIGR01917	glycine reductase, selenoprotein B
+various_sel_PB	TIGR01918	selenoprotein B, glycine/betaine/sarcosine/D-proline reductase family
+hisA-trpF	TIGR01919	bifunctional HisA/TrpF protein
+Shik_kin_archae	TIGR01920	shikimate kinase
+DAP-DH	TIGR01921	diaminopimelate dehydrogenase
+purO_arch	TIGR01922	IMP cyclohydrolase
+menE	TIGR01923	O-succinylbenzoate-CoA ligase
+rsbW_low_gc	TIGR01924	anti-sigma B factor
+spIIAB	TIGR01925	anti-sigma F factor
+peroxid_rel	TIGR01926	uncharacterized peroxidase-related enzyme
+menC_gamma/gm+	TIGR01927	o-succinylbenzoate synthase
+menC_lowGC/arch	TIGR01928	o-succinylbenzoate synthase
+menB	TIGR01929	naphthoate synthase
+AcCoA-C-Actrans	TIGR01930	acetyl-CoA C-acyltransferase
+cysJ	TIGR01931	sulfite reductase [NADPH] flavoprotein, alpha-component
+hflC	TIGR01932	HflC protein
+hflK	TIGR01933	HflK protein
+MenG_MenH_UbiE	TIGR01934	ubiquinone/menaquinone biosynthesis methyltransferase
+NOT-MenG	TIGR01935	RraA family
+nqrA	TIGR01936	NADH:ubiquinone oxidoreductase, Na(+)-translocating, A subunit
+nqrB	TIGR01937	NADH:ubiquinone oxidoreductase, Na(+)-translocating, B subunit
+nqrC	TIGR01938	NADH:ubiquinone oxidoreductase, Na(+)-translocating, C subunit
+nqrD	TIGR01939	NADH:ubiquinone oxidoreductase, Na(+)-translocating, D subunit
+nqrE	TIGR01940	NADH:ubiquinone oxidoreductase, Na(+)-translocating, E subunit
+nqrF	TIGR01941	NADH:ubiquinone oxidoreductase, Na(+)-translocating, F subunit
+pcnB	TIGR01942	poly(A) polymerase
+rnfA	TIGR01943	electron transport complex, RnfABCDGE type, A subunit
+rnfB	TIGR01944	electron transport complex, RnfABCDGE type, B subunit
+rnfC	TIGR01945	electron transport complex, RnfABCDGE type, C subunit
+rnfD	TIGR01946	electron transport complex, RnfABCDGE type, D subunit
+rnfG	TIGR01947	electron transport complex, RnfABCDGE type, G subunit
+rnfE	TIGR01948	electron transport complex, RnfABCDGE type, E subunit
+AroFGH_arch	TIGR01949	predicted phospho-2-dehydro-3-deoxyheptonate aldolase
+SoxR	TIGR01950	redox-sensitive transcriptional activator SoxR
+nusB	TIGR01951	transcription antitermination factor NusB
+nusA_arch	TIGR01952	NusA family KH domain protein, archaeal
+NusA	TIGR01953	transcription termination factor NusA
+nusA_Cterm_rpt	TIGR01954	transcription termination factor NusA, C-terminal duplication
+RfaH	TIGR01955	transcription elongation factor/antiterminator RfaH
+NusG_myco	TIGR01956	NusG family protein
+nuoB_fam	TIGR01957	NADH-quinone oxidoreductase, B subunit
+nuoE_fam	TIGR01958	NADH-quinone oxidoreductase, E subunit
+nuoF_fam	TIGR01959	NADH oxidoreductase (quinone), F subunit
+ndhF3_CO2	TIGR01960	NAD(P)H dehydrogenase, subunit NdhF3 family
+NuoC_fam	TIGR01961	NADH (or F420H2) dehydrogenase, subunit C
+NuoD	TIGR01962	NADH dehydrogenase (quinone), D subunit
+PHB_DH	TIGR01963	3-hydroxybutyrate dehydrogenase
+chpXY	TIGR01964	CO2 hydration protein
+VCBS_repeat	TIGR01965	VCBS repeat
+RNasePH	TIGR01966	ribonuclease PH
+DEAH_box_HrpA	TIGR01967	RNA helicase HrpA
+minD_bact	TIGR01968	septum site-determining protein MinD
+minD_arch	TIGR01969	cell division ATPase MinD
+DEAH_box_HrpB	TIGR01970	ATP-dependent helicase HrpB
+NuoI	TIGR01971	NADH-quinone oxidoreductase, chain I
+NDH_I_M	TIGR01972	proton-translocating NADH-quinone oxidoreductase, chain M
+NuoG	TIGR01973	NADH dehydrogenase (quinone), G subunit
+NDH_I_L	TIGR01974	proton-translocating NADH-quinone oxidoreductase, chain L
+isoAsp_dipep	TIGR01975	beta-aspartyl peptidase
+am_tr_V_VC1184	TIGR01976	cysteine desulfurase family protein
+am_tr_V_EF2568	TIGR01977	cysteine desulfurase family protein
+sufC	TIGR01978	FeS assembly ATPase SufC
+sufS	TIGR01979	cysteine desulfurase, SufS family
+sufB	TIGR01980	FeS assembly protein SufB
+sufD	TIGR01981	FeS assembly protein SufD
+UbiB	TIGR01982	2-polyprenylphenol 6-hydroxylase
+UbiG	TIGR01983	3-demethylubiquinone-9 3-O-methyltransferase
+UbiH	TIGR01984	2-polyprenyl-6-methoxyphenol 4-hydroxylase
+phasin_2	TIGR01985	phasin
+glut_syn_euk	TIGR01986	glutathione synthetase
+HI0074	TIGR01987	nucleotidyltransferase substrate binding protein, HI0074 family
+Ubi-OHases	TIGR01988	ubiquinone biosynthesis hydroxylase, UbiH/UbiF/VisC/COQ6 family
+COQ6	TIGR01989	ubiquinone biosynthesis monooxygenase COQ6
+bPGM	TIGR01990	beta-phosphoglucomutase
+HscA	TIGR01991	Fe-S protein assembly chaperone HscA
+PTS-IIBC-Tre	TIGR01992	PTS system, trehalose-specific IIBC component
+Pyr-5-nucltdase	TIGR01993	pyrimidine 5'-nucleotidase
+SUF_scaf_2	TIGR01994	SUF system FeS assembly protein, NifU family
+PTS-II-ABC-beta	TIGR01995	PTS system, beta-glucoside-specific IIABC component
+PTS-II-BC-sucr	TIGR01996	PTS system, sucrose-specific IIBC component
+sufA_proteo	TIGR01997	FeS assembly scaffold SufA
+PTS-II-BC-nag	TIGR01998	PTS system, N-acetylglucosamine-specific IIBC component
+iscU	TIGR01999	FeS cluster assembly scaffold IscU
+NifU_proper	TIGR02000	Fe-S cluster assembly protein NifU
+gcw_chp	TIGR02001	conserved hypothetical protein
+PTS-II-BC-glcB	TIGR02002	PTS system, glucose-specific IIBC component
+PTS-II-BC-unk1	TIGR02003	PTS system, IIBC component
+PTS-IIBC-malX	TIGR02004	PTS system, maltose and glucose-specific IIBC component
+PTS-IIBC-alpha	TIGR02005	PTS system, alpha-glucoside-specific IIBC component
+IscS	TIGR02006	cysteine desulfurase IscS
+fdx_isc	TIGR02007	ferredoxin, 2Fe-2S type, ISC system
+fdx_plant	TIGR02008	ferredoxin [2Fe-2S]
+PGMB-YQAB-SF	TIGR02009	beta-phosphoglucomutase family hydrolase
+IscR	TIGR02010	iron-sulfur cluster assembly transcription factor IscR
+IscA	TIGR02011	iron-sulfur cluster assembly protein IscA
+tigrfam_recA	TIGR02012	protein RecA
+rpoB	TIGR02013	DNA-directed RNA polymerase, beta subunit
+BchZ	TIGR02014	chlorophyllide reductase subunit Z
+BchY	TIGR02015	chlorophyllide reductase subunit Y
+BchX	TIGR02016	chlorophyllide reductase iron protein subunit X
+hutG_amidohyd	TIGR02017	N-formylglutamate deformylase
+his_ut_repres	TIGR02018	histidine utilization repressor
+BchJ	TIGR02019	bacteriochlorophyll 4-vinyl reductase
+BchF	TIGR02020	2-vinyl bacteriochlorophyllide hydratase
+BchM-ChlM	TIGR02021	magnesium protoporphyrin O-methyltransferase
+hutF	TIGR02022	formiminoglutamate deiminase
+BchP-ChlP	TIGR02023	geranylgeranyl reductase
+FtcD	TIGR02024	glutamate formiminotransferase
+BchH	TIGR02025	magnesium chelatase, H subunit
+BchE	TIGR02026	magnesium-protoporphyrin IX monomethyl ester anaerobic oxidative cyclase
+rpoA	TIGR02027	DNA-directed RNA polymerase, alpha subunit
+ChlP	TIGR02028	geranylgeranyl reductase
+AcsF	TIGR02029	magnesium-protoporphyrin IX monomethyl ester aerobic oxidative cyclase
+BchI-ChlI	TIGR02030	magnesium chelatase ATPase subunit I
+BchD-ChlD	TIGR02031	magnesium chelatase ATPase subunit D
+GG-red-SF	TIGR02032	geranylgeranyl reductase family
+D-hydantoinase	TIGR02033	dihydropyrimidinase
+CysN	TIGR02034	sulfate adenylyltransferase, large subunit
+D_Ser_am_lyase	TIGR02035	D-serine ammonia-lyase
+dsdC	TIGR02036	D-serine deaminase transcriptional activator
+degP_htrA_DO	TIGR02037	peptidase Do
+protease_degS	TIGR02038	periplasmic serine peptidase DegS
+CysD	TIGR02039	sulfate adenylyltransferase, small subunit
+PpsR-CrtJ	TIGR02040	transcriptional regulator PpsR
+CysI	TIGR02041	sulfite reductase (NADPH) hemoprotein, beta-component
+sir	TIGR02042	sulfite reductase, ferredoxin dependent
+ZntR	TIGR02043	Zn(II)-responsive transcriptional regulator
+CueR	TIGR02044	Cu(I)-responsive transcriptional regulator
+P_fruct_ADP	TIGR02045	ADP-specific phosphofructokinase
+sdhC_b558_fam	TIGR02046	succinate dehydrogenase (or fumarate reductase) cytochrome b subunit, b558 family
+CadR-PbrR	TIGR02047	Cd(II)/Pb(II)-responsive transcriptional regulator
+gshA_cyano	TIGR02048	putative glutamate--cysteine ligase
+gshA_ferroox	TIGR02049	glutamate--cysteine ligase
+gshA_cyan_rel	TIGR02050	carboxylate-amine ligase, YbdK family
+MerR	TIGR02051	Hg(II)-responsive transcriptional regulator
+MerP	TIGR02052	mercuric transport protein periplasmic component
+MerA	TIGR02053	mercury(II) reductase
+MerD	TIGR02054	mercuric resistence transcriptional repressor protein MerD
+APS_reductase	TIGR02055	adenylylsulfate reductase, thioredoxin dependent
+ChlG	TIGR02056	chlorophyll synthase ChlG
+PAPS_reductase	TIGR02057	phosphoadenosine phosphosulfate reductase
+lin0512_fam	TIGR02058	conserved hypothetical protein
+swm_rep_I	TIGR02059	cyanobacterial long protein repeat
+aprB	TIGR02060	adenylylsulfate reductase, beta subunit
+aprA	TIGR02061	adenylylsulfate reductase, alpha subunit
+RNase_B	TIGR02062	exoribonuclease II
+RNase_R	TIGR02063	ribonuclease R
+dsrA	TIGR02064	sulfite reductase, dissimilatory-type alpha subunit
+ECX1	TIGR02065	exosome complex exonuclease 1
+dsrB	TIGR02066	sulfite reductase, dissimilatory-type beta subunit
+his_9_HisN	TIGR02067	histidinol-phosphatase
+cya_phycin_syn	TIGR02068	cyanophycin synthetase
+cyanophycinase	TIGR02069	cyanophycinase
+mono_pep_trsgly	TIGR02070	monofunctional biosynthetic peptidoglycan transglycosylase
+PBP_1b	TIGR02071	penicillin-binding protein 1B
+BioC	TIGR02072	malonyl-acyl carrier protein O-methyltransferase BioC
+PBP_1c	TIGR02073	penicillin-binding protein 1C
+PBP_1a_fam	TIGR02074	penicillin-binding protein, 1A family
+pyrH_bact	TIGR02075	UMP kinase
+pyrH_arch	TIGR02076	putative uridylate kinase
+thr_lead_pep	TIGR02077	thr operon leader peptide
+AspKin_pair	TIGR02078	putative Pyrococcus aspartate kinase subunit
+THD1	TIGR02079	threonine dehydratase
+O_succ_thio_ly	TIGR02080	O-succinylhomoserine (thiol)-lyase
+metW	TIGR02081	methionine biosynthesis protein MetW
+metH	TIGR02082	methionine synthase
+LEU2	TIGR02083	3-isopropylmalate dehydratase, large subunit
+leud	TIGR02084	3-isopropylmalate dehydratase, small subunit
+meth_trns_rumB	TIGR02085	23S rRNA (uracil-5-)-methyltransferase RumB
+IPMI_arch	TIGR02086	3-isopropylmalate dehydratase, large subunit
+LEUD_arch	TIGR02087	3-isopropylmalate dehydratase, small subunit
+LEU3_arch	TIGR02088	isopropylmalate/isohomocitrate dehydrogenases
+TTC	TIGR02089	tartrate dehydrogenase
+LEU1_arch	TIGR02090	isopropylmalate/citramalate/homocitrate synthases
+glgC	TIGR02091	glucose-1-phosphate adenylyltransferase
+glgD	TIGR02092	glucose-1-phosphate adenylyltransferase, GlgD subunit
+P_ylase	TIGR02093	glycogen/starch/alpha-glucan phosphorylases
+more_P_ylases	TIGR02094	alpha-glucan phosphorylases
+glgA	TIGR02095	glycogen/starch synthase, ADP-glucose type
+TIGR02096	TIGR02096	conserved hypothetical protein
+yccV	TIGR02097	hemimethylated DNA binding domain
+MJ0042_CXXC	TIGR02098	MJ0042 family finger-like domain
+TIGR02099	TIGR02099	TIGR02099 family protein
+glgX_debranch	TIGR02100	glycogen debranching enzyme GlgX
+IpaC_SipC	TIGR02101	type III secretion target, IpaC/SipC family
+pullulan_Gpos	TIGR02102	pullulanase, extracellular
+pullul_strch	TIGR02103	alpha-1,6-glucosidases, pullulanase-type
+pulA_typeI	TIGR02104	pullulanase, type I
+III_needle	TIGR02105	type III secretion apparatus needle protein
+cyd_oper_ybgT	TIGR02106	cyd operon protein YbgT
+PQQ_syn_pqqA	TIGR02107	coenzyme PQQ precursor peptide PqqA
+PQQ_syn_pqqB	TIGR02108	coenzyme PQQ biosynthesis protein B
+PQQ_syn_pqqE	TIGR02109	coenzyme PQQ biosynthesis enzyme PqqE
+PQQ_syn_pqqF	TIGR02110	coenzyme PQQ biosynthesis protein PqqF
+PQQ_syn_pqqC	TIGR02111	coenzyme PQQ biosynthesis protein C
+cyd_oper_ybgE	TIGR02112	cyd operon protein YbgE
+coaC_strep	TIGR02113	phosphopantothenoylcysteine decarboxylase
+coaB_strep	TIGR02114	phosphopantothenate--cysteine ligase
+potass_kdpF	TIGR02115	K+-transporting ATPase, F subunit
+toxin_Txe_YoeB	TIGR02116	addiction module toxin, Txe/YoeB family
+chp_urease_rgn	TIGR02117	conserved hypothetical protein
+TIGR02118	TIGR02118	conserved hypothetical protein
+panF	TIGR02119	sodium/pantothenate symporter
+GspF	TIGR02120	type II secretion system protein F
+Na_Pro_sym	TIGR02121	sodium/proline symporter
+TRAP_TAXI	TIGR02122	TRAP transporter solute receptor, TAXI family
+TRAP_fused	TIGR02123	TRAP transporter, 4TM/12TM fusion protein
+hypE	TIGR02124	hydrogenase expression/formation protein HypE
+CytB-hydogenase	TIGR02125	Ni/Fe-hydrogenase, b-type cytochrome subunit
+phgtail_TP901_1	TIGR02126	phage major tail protein, TP901-1 family
+pyrF_sub2	TIGR02127	orotidine 5'-phosphate decarboxylase
+G6PI_arch	TIGR02128	bifunctional phosphoglucose/phosphomannose isomerase
+hisA_euk	TIGR02129	phosphoribosylformimino-5-aminoimidazole carboxamide ribotide isomerase
+dapB_plant	TIGR02130	dihydrodipicolinate reductase
+phaP_Bmeg	TIGR02131	polyhydroxyalkanoic acid inclusion protein PhaP
+phaR_Bmeg	TIGR02132	polyhydroxyalkanoic acid synthase, PhaR subunit
+RPI_actino	TIGR02133	ribose 5-phosphate isomerase
+transald_staph	TIGR02134	transaldolase
+phoU_full	TIGR02135	phosphate transport system regulatory protein PhoU
+ptsS_2	TIGR02136	phosphate binding protein
+HSK-PSP	TIGR02137	phosphoserine phosphatase/homoserine phosphotransferase bifunctional protein
+phosphate_pstC	TIGR02138	phosphate ABC transporter, permease protein PstC
+permease_CysT	TIGR02139	sulfate ABC transporter, permease protein CysT
+permease_CysW	TIGR02140	sulfate ABC transporter, permease protein CysW
+modB_ABC	TIGR02141	molybdate ABC transporter, permease protein
+modC_ABC	TIGR02142	molybdate ABC transporter, ATP-binding protein
+trmA_only	TIGR02143	tRNA (uracil(54)-C(5))-methyltransferase
+LysX_arch	TIGR02144	lysine biosynthesis enzyme LysX
+Fib_succ_major	TIGR02145	fibrobacter succinogenes major paralogous domain
+LysS_fung_arch	TIGR02146	homocitrate synthase
+Fsuc_second	TIGR02147	TIGR02147 family protein
+Fibro_Slime	TIGR02148	fibro-slime domain
+glgA_Coryne	TIGR02149	glycogen synthase, Corynebacterium family
+IPP_isom_1	TIGR02150	isopentenyl-diphosphate delta-isomerase
+IPP_isom_2	TIGR02151	isopentenyl-diphosphate delta-isomerase, type 2
+D_ribokin_bact	TIGR02152	ribokinase
+gatD_arch	TIGR02153	glutamyl-tRNA(Gln) amidotransferase, subunit D
+PhoB	TIGR02154	phosphate regulon transcriptional regulatory protein PhoB
+PA_CoA_ligase	TIGR02155	phenylacetate-CoA ligase
+PA_CoA_Oxy1	TIGR02156	phenylacetate-CoA oxygenase, PaaG subunit
+PA_CoA_Oxy2	TIGR02157	phenylacetate-CoA oxygenase, PaaH subunit
+PA_CoA_Oxy3	TIGR02158	phenylacetate-CoA oxygenase, PaaI subunit
+PA_CoA_Oxy4	TIGR02159	phenylacetate-CoA oxygenase, PaaJ subunit
+PA_CoA_Oxy5	TIGR02160	phenylacetate-CoA oxygenase/reductase, PaaK subunit
+napC_nirT	TIGR02161	periplasmic nitrate (or nitrite) reductase c-type cytochrome, NapC/NirT family
+torC	TIGR02162	trimethylamine-N-oxide reductase c-type cytochrome TorC
+napH_	TIGR02163	ferredoxin-type protein, NapH/MauN family
+torA	TIGR02164	trimethylamine-N-oxide reductase TorA
+cas5_6_GSU0054	TIGR02165	CRISPR-associated protein GSU0054/csb2, Dpsyc system
+dmsA_ynfE	TIGR02166	anaerobic dimethyl sulfoxide reductase, A subunit, DmsA/YnfE family
+Liste_lipo_26	TIGR02167	bacterial surface protein 26-residue repeat
+SMC_prok_B	TIGR02168	chromosome segregation protein SMC
+SMC_prok_A	TIGR02169	chromosome segregation protein SMC
+thyX	TIGR02170	thymidylate synthase, flavin-dependent
+Fb_sc_TIGR02171	TIGR02171	fibrobacter succinogenes paralogous family TIGR02171
+Fb_sc_TIGR02172	TIGR02172	fibrobacter succinogenes paralogous family TIGR02172
+cyt_kin_arch	TIGR02173	putative cytidylate kinase
+CXXU_selWTH	TIGR02174	selT/selW/selH selenoprotein domain
+PorC_KorC	TIGR02175	2-oxoacid:acceptor oxidoreductase, gamma subunit, pyruvate/2-ketoisovalerate family
+pyruv_ox_red	TIGR02176	pyruvate:ferredoxin (flavodoxin) oxidoreductase
+PorB_KorB	TIGR02177	2-oxoacid:acceptor oxidoreductase, beta subunit, pyruvate/2-ketoisovalerate family
+yeiP	TIGR02178	elongation factor P-like protein YeiP
+PorD_KorD	TIGR02179	2-oxoacid:acceptor oxidoreductase, delta subunit, pyruvate/2-ketoisovalerate family
+GRX_euk	TIGR02180	glutaredoxin
+GRX_bact	TIGR02181	glutaredoxin 3
+GRXB	TIGR02182	glutaredoxin, GrxB family
+GRXA	TIGR02183	glutaredoxin, GrxA family
+Myco_arth_vir_N	TIGR02184	Mycoplasma virulence family signal region
+Trep_Strep	TIGR02185	putative ECF transporter S component, Trep_Strep family
+alph_Pro_TM	TIGR02186	conserved hypothetical protein
+GlrX_arch	TIGR02187	glutaredoxin-like domain protein
+Ac_CoA_lig_AcsA	TIGR02188	acetate--CoA ligase
+GlrX-like_plant	TIGR02189	glutaredoxin-like family
+GlrX-dom	TIGR02190	glutaredoxin-family domain
+RNaseIII	TIGR02191	ribonuclease III
+HtrL_YibB	TIGR02192	protein YibB
+heptsyl_trn_I	TIGR02193	lipopolysaccharide heptosyltransferase I
+GlrX_NrdH	TIGR02194	glutaredoxin-like protein NrdH
+heptsyl_trn_II	TIGR02195	lipopolysaccharide heptosyltransferase II
+GlrX_YruB	TIGR02196	glutaredoxin-like protein, YruB-family
+heptose_epim	TIGR02197	ADP-glyceromanno-heptose 6-epimerase
+rfaE_dom_I	TIGR02198	bifunctional protein RfaE, domain I
+rfaE_dom_II	TIGR02199	bifunctional protein RfaE, domain II
+GlrX_actino	TIGR02200	glutaredoxin-like protein
+heptsyl_trn_III	TIGR02201	putative lipopolysaccharide heptosyltransferase III
+Ehrlichia_rpt	TIGR02202	Ehrlichia chaffeensis immunodominant surface protein repeat
+MsbA_lipidA	TIGR02203	lipid A export permease/ATP-binding protein MsbA
+MsbA_rel	TIGR02204	ABC transporter, permease/ATP-binding protein
+septum_zipA	TIGR02205	cell division protein ZipA
+intg_mem_TP0381	TIGR02206	conserved hypothetical integral membrane protein TIGR02206
+lipid_A_htrB	TIGR02207	lipid A biosynthesis lauroyl (or palmitoleoyl) acyltransferase
+lipid_A_msbB	TIGR02208	lipid A biosynthesis (KDO)2-(lauroyl)-lipid IVA acyltransferase
+ftsL_broad	TIGR02209	cell division protein FtsL
+rodA_shape	TIGR02210	rod shape-determining protein RodA
+LolD_lipo_ex	TIGR02211	lipoprotein releasing system, ATP-binding protein
+lolCE	TIGR02212	lipoprotein releasing system, transmembrane protein, LolC/E family
+lolE_release	TIGR02213	lipoprotein releasing system, transmembrane protein LolE
+spoVD_pbp	TIGR02214	stage V sporulation protein D
+phage_chp_gp8	TIGR02215	phage conserved hypothetical protein, phiE125 gp8 family
+phage_TIGR02216	TIGR02216	phage conserved hypothetical protein
+chp_TIGR02217	TIGR02217	TIGR02217 family protein
+phg_TIGR02218	TIGR02218	phage conserved hypothetical protein BR0599
+phage_NlpC_fam	TIGR02219	putative phage cell wall peptidase, NlpC/P60 family
+phg_TIGR02220	TIGR02220	phage conserved hypothetical protein, C-terminal domain
+cas_TM1812	TIGR02221	CRISPR-associated protein, TM1812 family
+chap_CsaA	TIGR02222	export-related chaperone protein CsaA
+ftsN	TIGR02223	cell division protein FtsN
+recomb_XerC	TIGR02224	tyrosine recombinase XerC
+recomb_XerD	TIGR02225	tyrosine recombinase XerD
+two_anch	TIGR02226	N-terminal double-transmembrane domain
+sigpep_I_bact	TIGR02227	signal peptidase I
+sigpep_I_arch	TIGR02228	signal peptidase I
+caa3_sub_IV	TIGR02229	caa(3)-type oxidase, subunit IV
+ATPase_gene1	TIGR02230	putative F0F1-ATPase subunit
+TIGR02231	TIGR02231	conserved hypothetical protein
+myxo_disulf_rpt	TIGR02232	Myxococcus cysteine-rich repeat
+trp_oprn_chp	TIGR02234	membrane protein, TIGR02234 family
+menA_cyano-plnt	TIGR02235	1,4-dihydroxy-2-naphthoate phytyltransferase
+recomb_radA	TIGR02236	DNA repair and recombination protein RadA
+recomb_radB	TIGR02237	DNA repair and recombination protein RadB
+recomb_DMC1	TIGR02238	meiotic recombinase Dmc1
+recomb_RAD51	TIGR02239	DNA repair protein RAD51
+PHA_depoly_arom	TIGR02240	poly(3-hydroxyalkanoate) depolymerase
+TIGR02241	TIGR02241	conserved hypothetical phage tail region protein
+tail_TIGR02242	TIGR02242	phage tail protein domain
+TIGR02243	TIGR02243	putative baseplate assembly protein
+HAD-IG-Ncltidse	TIGR02244	HAD superfamily (subfamily IG) hydrolase, 5'-nucleotidase
+HAD_IIID1	TIGR02245	HAD hydrolase, family IIID
+TIGR02246	TIGR02246	conserved hypothetical protein
+HAD-1A3-hyp	TIGR02247	epoxide hydrolase N-terminal domain-like phosphatase
+mutH_TIGR	TIGR02248	DNA mismatch repair endonuclease MutH
+integrase_gron	TIGR02249	integron integrase
+FCP1_euk	TIGR02250	FCP1-like phosphatase, phosphatase domain
+HIF-SF_euk	TIGR02251	dullard-like phosphatase domain
+DREG-2	TIGR02252	HAD hydrolase, REG-2-like, family IA
+CTE7	TIGR02253	HAD hydrolase, TIGR02253 family
+YjjG/YfnB	TIGR02254	noncanonical pyrimidine nucleotidase, YjjG family
+ICE_VC0181	TIGR02256	conserved hypothetical protein
+cobalto_cobN	TIGR02257	cobaltochelatase, CobN subunit
+2_5_ligase	TIGR02258	2'-5' RNA ligase
+benz_CoA_red_A	TIGR02259	benzoyl-CoA reductase, subunit A
+benz_CoA_red_B	TIGR02260	benzoyl-CoA reductase, subunit B
+benz_CoA_red_D	TIGR02261	benzoyl-CoA reductase, subunit D
+benz_CoA_lig	TIGR02262	benzoate-CoA ligase family
+benz_CoA_red_C	TIGR02263	benzoyl-CoA reductase, subunit C
+gmx_para_CXXCG	TIGR02264	Myxococcus xanthus double-CXXCG motif paralogous family
+Mxa_TIGR02265	TIGR02265	Myxococcales-restricted protein, TIGR02265 family
+gmx_TIGR02266	TIGR02266	Myxococcus xanthus paralogous domain TIGR02266
+TIGR02267	TIGR02267	DUSAM domain
+TIGR02268	TIGR02268	Myxococcus xanthus paralogous family TIGR02268
+TIGR02269	TIGR02269	Myxococcus xanthus paralogous lipoprotein family TIGR02269
+TIGR02270	TIGR02270	conserved hypothetical protein
+TIGR02271	TIGR02271	conserved domain
+gentisate_1_2	TIGR02272	gentisate 1,2-dioxygenase
+16S_RimM	TIGR02273	16S rRNA processing protein RimM
+dCTP_deam	TIGR02274	deoxycytidine triphosphate deaminase
+DHB_AMP_lig	TIGR02275	(2,3-dihydroxybenzoyl)adenylate synthase
+beta_rpt_yvtn	TIGR02276	40-residue YVTN family beta-propeller repeat
+PaaX_trns_reg	TIGR02277	phenylacetic acid degradation operon negative regulatory protein PaaX
+PaaN-DH	TIGR02278	phenylacetic acid degradation protein paaN
+PaaC-3OHAcCoADH	TIGR02279	3-hydroxyacyl-CoA dehydrogenase PaaC
+PaaB1	TIGR02280	phenylacetate degradation probable enoyl-CoA hydratase PaaB
+clan_AA_DTGA	TIGR02281	clan AA aspartic protease, TIGR02281 family
+MltB	TIGR02282	lytic murein transglycosylase B
+MltB_2	TIGR02283	lytic murein transglycosylase
+TIGR02284	TIGR02284	conserved hypothetical protein
+TIGR02285	TIGR02285	conserved hypothetical protein
+PaaD	TIGR02286	phenylacetic acid degradation protein PaaD
+PaaY	TIGR02287	phenylacetic acid degradation protein PaaY
+PaaN_2	TIGR02288	phenylacetic acid degradation protein paaN
+M3_not_pepF	TIGR02289	oligoendopeptidase, M3 family
+M3_fam_3	TIGR02290	oligoendopeptidase, pepF/M3 family
+rimK_rel_E_lig	TIGR02291	alpha-L-glutamate ligase homolog
+ygfB_yecA	TIGR02292	yecA family protein
+TAS_TIGR02293	TIGR02293	putative toxin-antitoxin system antitoxin component, TIGR02293 family
+nickel_nikA	TIGR02294	nickel ABC transporter, nickel/metallophore periplasmic binding protein
+HpaD	TIGR02295	3,4-dihydroxyphenylacetate 2,3-dioxygenase
+HpaC	TIGR02296	4-hydroxyphenylacetate 3-monooxygenase, reductase component
+HpaA	TIGR02297	4-hydroxyphenylacetate catabolism regulatory protein HpaA
+HpaD_Fe	TIGR02298	3,4-dihydroxyphenylacetate 2,3-dioxygenase
+HpaE	TIGR02299	5-carboxymethyl-2-hydroxymuconate semialdehyde dehydrogenase
+FYDLN_acid	TIGR02300	TIGR02300 family protein
+TIGR02301	TIGR02301	TIGR02301 family protein
+aProt_lowcomp	TIGR02302	TIGR02302 family protein
+HpaG-C-term	TIGR02303	4-hydroxyphenylacetate degradation bifunctional isomerase/decarboxylase, C-terminal subunit
+aden_form_hyp	TIGR02304	putative adenylate-forming enzyme
+HpaG-N-term	TIGR02305	4-hydroxyphenylacetate degradation bifunctional isomerase/decarboxylase, N-terminal subunit
+RNA_lig_DRB0094	TIGR02306	RNA ligase
+RNA_lig_RNL2	TIGR02307	RNA ligase, Rnl2 family
+RNA_lig_T4_1	TIGR02308	RNA ligase, T4 RnlA family
+HpaB-1	TIGR02309	4-hydroxyphenylacetate 3-monooxygenase, oxygenase component
+HpaB-2	TIGR02310	4-hydroxyphenylacetate 3-monooxygenase, oxygenase component
+HpaI	TIGR02311	2,4-dihydroxyhept-2-ene-1,7-dioic acid aldolase
+HpaH	TIGR02312	2-oxo-hepta-3-ene-1,7-dioic acid hydratase
+HpaI-NOT-DapA	TIGR02313	2,4-dihydroxyhept-2-ene-1,7-dioic acid aldolase
+ABC_MetN	TIGR02314	D-methionine ABC transporter, ATP-binding protein
+ABC_phnC	TIGR02315	phosphonate ABC transporter, ATP-binding protein
+propion_prpE	TIGR02316	propionate--CoA ligase
+prpB	TIGR02317	methylisocitrate lyase
+phosphono_phnM	TIGR02318	phosphonate metabolism protein PhnM
+CPEP_Pphonmut	TIGR02319	carboxyvinyl-carboxyphosphonate phosphorylmutase
+PEP_mutase	TIGR02320	phosphoenolpyruvate mutase
+Pphn_pyruv_hyd	TIGR02321	phosphonopyruvate hydrolase
+phosphon_PhnN	TIGR02322	phosphonate metabolism protein/1,5-bisphosphokinase (PRPP-forming) PhnN
+CP_lyasePhnK	TIGR02323	phosphonate C-P lyase system protein PhnK
+CP_lyasePhnL	TIGR02324	phosphonate C-P lyase system protein PhnL
+C_P_lyase_phnF	TIGR02325	phosphonate metabolism transcriptional regulator PhnF
+transamin_PhnW	TIGR02326	2-aminoethylphosphonate--pyruvate transaminase
+int_mem_ywzB	TIGR02327	conserved hypothetical integral membrane protein
+TIGR02328	TIGR02328	conserved hypothetical protein
+propionate_PrpR	TIGR02329	propionate catabolism operon regulatory protein PrpR
+prpD	TIGR02330	2-methylcitrate dehydratase
+rib_alpha	TIGR02331	Rib/alpha/Esp surface antigen repeat
+HpaX	TIGR02332	4-hydroxyphenylacetate permease
+2met_isocit_dHY	TIGR02333	2-methylisocitrate dehydratase, Fe/S-dependent
+prpF	TIGR02334	probable AcnD-accessory protein PrpF
+hydr_PhnA	TIGR02335	phosphonoacetate hydrolase
+TIGR02336	TIGR02336	1,3-beta-galactosyl-N-acetylhexosamine phosphorylase
+HpaR	TIGR02337	homoprotocatechuate degradation operon regulator, HpaR
+gimC_beta	TIGR02338	prefoldin, beta subunit
+thermosome_arch	TIGR02339	thermosome, various subunits, archaeal
+chap_CCT_alpha	TIGR02340	T-complex protein 1, alpha subunit
+chap_CCT_beta	TIGR02341	T-complex protein 1, beta subunit
+chap_CCT_delta	TIGR02342	T-complex protein 1, delta subunit
+chap_CCT_epsi	TIGR02343	T-complex protein 1, epsilon subunit
+chap_CCT_gamma	TIGR02344	T-complex protein 1, gamma subunit
+chap_CCT_eta	TIGR02345	T-complex protein 1, eta subunit
+chap_CCT_theta	TIGR02346	T-complex protein 1, theta subunit
+chap_CCT_zeta	TIGR02347	T-complex protein 1, zeta subunit
+GroEL	TIGR02348	chaperonin GroL
+DnaJ_bact	TIGR02349	chaperone protein DnaJ
+prok_dnaK	TIGR02350	chaperone protein DnaK
+thiH	TIGR02351	thiazole biosynthesis protein ThiH
+thiamin_ThiO	TIGR02352	glycine oxidase ThiO
+NRPS_term_dom	TIGR02353	non-ribosomal peptide synthetase terminal domain of unknown function
+thiF_fam2	TIGR02354	thiamine biosynthesis protein ThiF
+moeB	TIGR02355	molybdopterin synthase sulfurylase MoeB
+adenyl_thiF	TIGR02356	thiazole biosynthesis adenylyltransferase ThiF
+ECF_ThiT_YuaJ	TIGR02357	energy-coupled thiamine transporter ThiT
+thia_cytX	TIGR02358	putative hydroxymethylpyrimidine transporter CytX
+thiW	TIGR02359	energy coupling factor transporter S component ThiW
+pbenz_hydroxyl	TIGR02360	4-hydroxybenzoate 3-monooxygenase
+dak_ATP	TIGR02361	dihydroxyacetone kinase
+dhaK1b	TIGR02362	probable dihydroxyacetone kinase DhaK1b subunit
+dhaK1	TIGR02363	dihydroxyacetone kinase, DhaK subunit
+dha_pts	TIGR02364	dihydroxyacetone kinase, phosphotransfer subunit
+dha_L_ycgS	TIGR02365	dihydroxyacetone kinase, L subunit
+DHAK_reg	TIGR02366	probable dihydroxyacetone kinase regulator
+PylS_Cterm	TIGR02367	pyrrolysine--tRNA ligase, C-terminal region
+dimeth_PyL	TIGR02368	dimethylamine:corrinoid methyltransferase
+trimeth_pyl	TIGR02369	trimethylamine:corrinoid methyltransferase
+pyl_corrinoid	TIGR02370	methyltransferase cognate corrinoid proteins, Methanosarcina family
+ala_DH_arch	TIGR02371	alanine dehydrogenase
+4_coum_CoA_lig	TIGR02372	4-coumarate--CoA ligase
+photo_yellow	TIGR02373	photoactive yellow protein
+nitri_red_nirB	TIGR02374	nitrite reductase [NAD(P)H], large subunit
+pseudoazurin	TIGR02375	pseudoazurin
+Cu_nitrite_red	TIGR02376	nitrite reductase, copper-containing
+MocE_fam_FeS	TIGR02377	Rieske [2Fe-2S] domain protein, MocE subfamily
+nirD_assim_sml	TIGR02378	nitrite reductase [NAD(P)H], small subunit
+ECA_wecE	TIGR02379	TDP-4-keto-6-deoxy-D-glucose transaminase
+ECA_wecA	TIGR02380	undecaprenyl-phosphate alpha-N-acetylglucosaminyl 1-phosphatetransferase
+cspD	TIGR02381	cold shock domain protein CspD
+wecD_rffC	TIGR02382	TDP-D-fucosamine acetyltransferase
+Hfq	TIGR02383	RNA chaperone Hfq
+RelB_DinJ	TIGR02384	addiction module antitoxin, RelB/DinJ family
+RelE_StbE	TIGR02385	addiction module toxin, RelE/StbE family
+rpoC_TIGR	TIGR02386	DNA-directed RNA polymerase, beta' subunit
+rpoC1_cyan	TIGR02387	DNA-directed RNA polymerase, gamma subunit
+rpoC2_cyan	TIGR02388	DNA-directed RNA polymerase, beta'' subunit
+RNA_pol_rpoA2	TIGR02389	DNA-directed RNA polymerase, subunit A''
+RNA_pol_rpoA1	TIGR02390	DNA-directed RNA polymerase subunit A'
+hypoth_ymh	TIGR02391	TIGR02391 family protein
+rpoH_proteo	TIGR02392	alternative sigma factor RpoH
+RpoD_Cterm	TIGR02393	RNA polymerase sigma factor RpoD
+rpoS_proteo	TIGR02394	RNA polymerase sigma factor RpoS
+rpoN_sigma	TIGR02395	RNA polymerase sigma-54 factor
+diverge_rpsU	TIGR02396	rpsU-divergently transcribed protein
+dnaX_nterm	TIGR02397	DNA polymerase III, subunit gamma and tau
+gluc_glyc_Psyn	TIGR02398	glucosylglycerol-phosphate synthase
+salt_tol_Pase	TIGR02399	glucosylglycerol 3-phosphatase
+trehalose_OtsA	TIGR02400	alpha,alpha-trehalose-phosphate synthase (UDP-forming)
+trehalose_TreY	TIGR02401	malto-oligosyltrehalose synthase
+trehalose_TreZ	TIGR02402	malto-oligosyltrehalose trehalohydrolase
+trehalose_treC	TIGR02403	alpha,alpha-phosphotrehalase
+trehalos_R_Bsub	TIGR02404	trehalose operon repressor
+trehalos_R_Ecol	TIGR02405	trehalose operon repressor
+ectoine_EctA	TIGR02406	diaminobutyrate acetyltransferase
+ectoine_ectB	TIGR02407	diaminobutyrate--2-oxoglutarate aminotransferase
+ectoine_ThpD	TIGR02408	ectoine hydroxylase
+carnitine_bodg	TIGR02409	gamma-butyrobetaine hydroxylase
+carnitine_TMLD	TIGR02410	trimethyllysine dioxygenase
+leuko_A4_hydro	TIGR02411	leukotriene A-4 hydrolase/aminopeptidase
+pepN_strep_liv	TIGR02412	aminopeptidase N
+Bac_small_yrzI	TIGR02413	Bacillus tandem small hypothetical protein
+pepN_proteo	TIGR02414	aminopeptidase N
+23BDH	TIGR02415	acetoin reductases
+CO_dehy_Mo_lg	TIGR02416	carbon-monoxide dehydrogenase, large subunit
+fruct_sucro_rep	TIGR02417	D-fructose-responsive transcription factor
+acolac_catab	TIGR02418	acetolactate synthase, catabolic
+C4_traR_proteo	TIGR02419	phage/conjugal plasmid C-4 type zinc finger protein, TraR family
+dksA	TIGR02420	RNA polymerase-binding protein DksA
+QEGLA	TIGR02421	conserved hypothetical protein
+protocat_beta	TIGR02422	protocatechuate 3,4-dioxygenase, beta subunit
+protocat_alph	TIGR02423	protocatechuate 3,4-dioxygenase, alpha subunit
+TF_pcaQ	TIGR02424	pca operon transcription factor PcaQ
+decarb_PcaC	TIGR02425	4-carboxymuconolactone decarboxylase
+protocat_pcaB	TIGR02426	3-carboxy-cis,cis-muconate cycloisomerase
+protocat_pcaD	TIGR02427	3-oxoadipate enol-lactonase
+pcaJ_scoB_fam	TIGR02428	3-oxoacid CoA-transferase, B subunit
+pcaI_scoA_fam	TIGR02429	3-oxoacid CoA-transferase, A subunit
+pcaF	TIGR02430	3-oxoadipyl-CoA thiolase
+pcaR_pcaU	TIGR02431	beta-ketoadipate pathway transcriptional regulators, PcaR/PcaU/PobR family
+lysidine_TilS_N	TIGR02432	tRNA(Ile)-lysidine synthetase
+lysidine_TilS_C	TIGR02433	tRNA(Ile)-lysidine synthetase, C-terminal domain
+CobF	TIGR02434	precorrin-6A synthase (deacetylating)
+CobG	TIGR02435	precorrin-3B synthase
+TIGR02436	TIGR02436	four helix bundle protein
+FadB	TIGR02437	fatty oxidation complex, alpha subunit FadB
+catachol_actin	TIGR02438	catechol 1,2-dioxygenase
+catechol_proteo	TIGR02439	catechol 1,2-dioxygenase
+FadJ	TIGR02440	fatty oxidation complex, alpha subunit FadJ
+fa_ox_alpha_mit	TIGR02441	fatty acid oxidation complex, alpha subunit, mitochondrial
+Cob-chelat-sub	TIGR02442	cobaltochelatase subunit
+TIGR02443	TIGR02443	conserved hypothetical protein
+TIGR02444	TIGR02444	TIGR02444 family protein
+fadA	TIGR02445	acetyl-CoA C-acyltransferase FadA
+FadI	TIGR02446	acetyl-CoA C-acyltransferase FadI
+yiiD_Cterm	TIGR02447	putative thioesterase domain
+TIGR02448	TIGR02448	conserverd hypothetical protein
+TIGR02449	TIGR02449	TIGR02449 family protein
+TIGR02450	TIGR02450	tryptophan-rich conserved hypothetical protein
+anti_sig_ChrR	TIGR02451	anti-sigma factor, putative, ChrR family
+TIGR02452	TIGR02452	TIGR02452 family protein
+TIGR02453	TIGR02453	TIGR02453 family protein
+ECF_T_CbiQ	TIGR02454	cobalt ECF transporter T component CbiQ
+TreS_stutzeri	TIGR02455	trehalose synthase
+treS_nterm	TIGR02456	trehalose synthase
+TreS_Cterm	TIGR02457	putative maltokinase
+CbtA	TIGR02458	cobalt transporter subunit CbtA (proposed)
+CbtB	TIGR02459	cobalt transporter subunit CbtB (proposed)
+osmo_MPGsynth	TIGR02460	mannosyl-3-phosphoglycerate synthase
+osmo_MPG_phos	TIGR02461	mannosyl-3-phosphoglycerate phosphatase
+pyranose_ox	TIGR02462	pyranose oxidase
+MPGP_rel	TIGR02463	mannosyl-3-phosphoglycerate phosphatase homolog
+ribofla_fusion	TIGR02464	conserved hypothetical protein
+chlorocat_1_2	TIGR02465	chlorocatechol 1,2-dioxygenase
+TIGR02466	TIGR02466	conserved hypothetical protein
+CbiE	TIGR02467	precorrin-6y C5,15-methyltransferase (decarboxylating), CbiE subunit
+sucrsPsyn_pln	TIGR02468	sucrose phosphate synthase
+CbiT	TIGR02469	precorrin-6Y C5,15-methyltransferase (decarboxylating), CbiT subunit
+sucr_synth	TIGR02470	sucrose synthase
+sucr_syn_bact_C	TIGR02471	sucrose-phosphate synthase, sucrose phosphatase-like domain
+sucr_P_syn_N	TIGR02472	sucrose-phosphate synthase, putative, glycosyltransferase domain
+flagell_FliJ	TIGR02473	flagellar export protein FliJ
+pec_lyase	TIGR02474	pectate lyase
+CobW	TIGR02475	cobalamin biosynthesis protein CobW
+BluB	TIGR02476	5,6-dimethylbenzimidazole synthase
+PFKA_PPi	TIGR02477	diphosphate--fructose-6-phosphate 1-phosphotransferase
+6PF1K_euk	TIGR02478	6-phosphofructokinase
+FliA_WhiG	TIGR02479	RNA polymerase sigma factor, FliA/WhiG family
+fliN	TIGR02480	flagellar motor switch protein FliN
+hemeryth_dom	TIGR02481	hemerythrin-like metal-binding domain
+PFKA_ATP	TIGR02482	6-phosphofructokinase
+PFK_mixed	TIGR02483	phosphofructokinase
+CitB	TIGR02484	CitB domain protein
+CobZ_N-term	TIGR02485	precorrin 3B synthase CobZ
+RDH	TIGR02486	reductive dehalogenase
+NrdD	TIGR02487	anaerobic ribonucleoside-triphosphate reductase
+flgG_G_neg	TIGR02488	flagellar basal-body rod protein FlgG
+flgE_epsilon	TIGR02489	flagellar hook protein FlgE
+flgF	TIGR02490	flagellar basal-body rod protein FlgF
+NrdG	TIGR02491	anaerobic ribonucleoside-triphosphate reductase activating protein
+flgK_ends	TIGR02492	flagellar hook-associated protein FlgK
+PFLA	TIGR02493	pyruvate formate-lyase 1-activating enzyme
+PFLE_PFLC	TIGR02494	glycyl-radical enzyme activating protein
+NrdG2	TIGR02495	anaerobic ribonucleoside-triphosphate reductase activating protein
+yscI_hrpB_dom	TIGR02497	type III secretion apparatus protein, YscI/HrpB, C-terminal domain
+type_III_ssaH	TIGR02498	type III secretion system protein, SsaH family
+HrpE_YscL_not	TIGR02499	type III secretion apparatus protein, HrpE/YscL family
+type_III_yscD	TIGR02500	type III secretion apparatus protein, YscD/HrpQ family
+type_III_yscE	TIGR02501	type III secretion system protein, YseE family
+type_III_YscX	TIGR02502	type III secretion protein, YscX family
+type_III_SycN	TIGR02503	type III secretion chaperone SycN
+NrdJ_Z	TIGR02504	ribonucleoside-diphosphate reductase, adenosylcobalamin-dependent
+RTPR	TIGR02505	ribonucleoside-triphosphate reductase, adenosylcobalamin-dependent
+NrdE_NrdA	TIGR02506	ribonucleoside-diphosphate reductase, alpha subunit
+MtrF	TIGR02507	tetrahydromethanopterin S-methyltransferase, F subunit
+type_III_yscG	TIGR02508	type III secretion protein, YscG family
+type_III_yopR	TIGR02509	type III secretion effector, YopR family
+NrdE-prime	TIGR02510	ribonucleoside-diphosphate reductase, alpha chain
+type_III_tyeA	TIGR02511	type III secretion effector delivery regulator, TyeA family
+FeFe_hydrog_A	TIGR02512	[FeFe] hydrogenase, group A
+type_III_yscB	TIGR02513	type III secretion system chaperone, YscB family
+type_III_yscP	TIGR02514	type III secretion system needle length determinant
+IV_pilus_PilQ	TIGR02515	type IV pilus secretin PilQ
+type_III_yscC	TIGR02516	type III secretion outer membrane pore, YscC/HrcC family
+type_II_gspD	TIGR02517	type II secretion system protein D
+EutH_ACDH	TIGR02518	acetaldehyde dehydrogenase (acetylating)
+pilus_MshL	TIGR02519	pilus (MSHA type) biogenesis protein MshL
+pilus_B_mal_scr	TIGR02520	type IVB pilus formation outer membrane protein, R64 PilN family
+type_IV_pilW	TIGR02521	type IV pilus biogenesis/stability protein PilW
+pilus_cpaD	TIGR02522	pilus (Caulobacter type) biogenesis lipoprotein CpaD
+type_IV_pilV	TIGR02523	type IV pilus modification protein PilV
+dot_icm_DotB	TIGR02524	Dot/Icm secretion system ATPase DotB
+plasmid_TraJ	TIGR02525	plasmid transfer ATPase TraJ
+eut_PduT	TIGR02526	PduT-like ethanolamine utilization protein
+dot_icm_IcmQ	TIGR02527	Dot/Icm secretion system protein IcmQ
+EutP	TIGR02528	ethanolamine utilization protein, EutP
+EutJ	TIGR02529	ethanolamine utilization protein EutJ family protein
+flg_new	TIGR02530	flagellar operon protein
+yecD_yerC	TIGR02531	TrpR homolog YerC/YecD
+IV_pilin_GFxxxE	TIGR02532	prepilin-type N-terminal cleavage/methylation domain
+type_II_gspE	TIGR02533	type II secretion system protein E
+mucon_cyclo	TIGR02534	muconate and chloromuconate cycloisomerases
+hyp_Hser_kinase	TIGR02535	proposed homoserine kinase
+eut_hyp	TIGR02536	ethanolamine utilization protein
+arch_flag_Nterm	TIGR02537	archaeal flagellin N-terminal-like domain
+type_IV_pilB	TIGR02538	type IV-A pilus assembly ATPase PilB
+SepCysS	TIGR02539	O-phospho-L-seryl-tRNA:Cys-tRNA synthase
+gpx7	TIGR02540	putative glutathione peroxidase Gpx7
+flagell_FlgJ	TIGR02541	flagellar rod assembly protein/muramidase FlgJ
+T_forsyth_147	TIGR02542	TANFOR domain
+List_Bact_rpt	TIGR02543	repeat, TIGR02543 family
+III_secr_YscJ	TIGR02544	type III secretion apparatus lipoprotein, YscJ/HrcJ family
+III_secr_ATP	TIGR02546	type III secretion apparatus H+-transporting two-sector ATPase
+casA_cse1	TIGR02547	CRISPR type I-E/ECOLI-associated protein CasA/Cse1
+casB_cse2	TIGR02548	CRISPR type I-E/ECOLI-associated protein CasB/Cse2
+CRISPR_DxTHG	TIGR02549	CRISPR-associated DxTHG motif protein
+flagell_flgL	TIGR02550	flagellar hook-associated protein 3
+SpaO_YscQ	TIGR02551	type III secretion apparatus protein, YscQ/HrcQ family
+LcrH_SycD	TIGR02552	type III secretion low calcium response chaperone LcrH/SycD
+SipD_IpaD_SspD	TIGR02553	type III effector protein IpaD/SipD/SspD
+PrgH	TIGR02554	type III secretion apparatus protein PrgH/EprH
+OrgA_MxiK	TIGR02555	type III secretion apparatus protein OrgA/MxiK
+cas_TM1802	TIGR02556	CRISPR-associated protein, TM1802 family
+HpaP	TIGR02557	type III secretion protein HpaP
+HrpB2	TIGR02558	type III secretion protein HrpB2
+HrpB7	TIGR02559	type III secretion protein HrpB7
+HrpB4	TIGR02560	type III secretion protein HrpB4
+HrpB1_HrpK	TIGR02561	type III secretion protein HrpB1/HrpK
+cas3_yersinia	TIGR02562	CRISPR-associated helicase Cas3, subtype I-F/YPEST
+cas_Csy4	TIGR02563	CRISPR-associated endoribonuclease Cas6/Csy4, subtype I-F/YPEST
+cas_Csy1	TIGR02564	CRISPR type I-F/YPEST-associated protein Csy1
+cas_Csy2	TIGR02565	CRISPR type I-F/YPEST-associated protein Csy2
+cas_Csy3	TIGR02566	CRISPR type I-F/YPEST-associated protein Csy3
+YscW	TIGR02567	type III secretion system chaperone YscW
+LcrE	TIGR02568	type III secretion regulator YopN/LcrE/InvE/MxiC
+TIGR02569_actnb	TIGR02569	TIGR02569 family protein
+cas7_GSU0053	TIGR02570	CRISPR-associated protein GSU0053/csb1, Dpsyc system
+ComEB	TIGR02571	ComE operon protein 2
+LcrR	TIGR02572	type III secretion system regulator LcrR
+LcrG_PcrG	TIGR02573	type III secretion protein LcrG
+stabl_TIGR02574	TIGR02574	putative addiction module component, TIGR02574 family
+cas_TM1794_Cmr2	TIGR02577	CRISPR-associated protein Cas10/Cmr2, subtype III-B
+cas_TM1811_Csm1	TIGR02578	CRISPR-associated protein Cas10/Csm1, subtype III-A/MTUBE
+cas_csx3	TIGR02579	CRISPR-associated protein, Csx3 family
+cas_RAMP_Cmr4	TIGR02580	CRISPR type III-B/RAMP module RAMP protein Cmr4
+cas_cyan_RAMP	TIGR02581	CRISPR-associated RAMP protein, SSO1426 family
+cas7_TM1809	TIGR02582	CRISPR type III-A/MTUBE-associated RAMP protein Csm3
+DevR_archaea	TIGR02583	CRISPR-associated protein Cas7/Csa2, subtype I-A/APERN
+cas_NE0113	TIGR02584	CRISPR-associated protein, NE0113 family
+cas_Cst2_DevR	TIGR02585	CRISPR-associated protein Cas7/Cst2/DevR, subtype I-B/TNEAP
+cas5_cmx5_devS	TIGR02586	CRISPR-associated protein Cas5/DevS, subtype MYXAN
+TIGR02587	TIGR02587	putative integral membrane protein TIGR02587
+TIGR02588	TIGR02588	TIGR02588 family protein
+cas_Csd2	TIGR02589	CRISPR-associated protein Cas7/Csd2, subtype I-C/DVULG
+cas_Csh2	TIGR02590	CRISPR-associated protein Cas7/Csh2, subtype I-B/HMARI
+cas_Csh1	TIGR02591	CRISPR-associated protein Cas8b/Csh1, subtype I-B/HMARI
+cas_Cas5h	TIGR02592	CRISPR-associated protein Cas5, subtype I-B/HMARI
+CRISPR_cas5	TIGR02593	CRISPR-associated protein Cas5
+TIGR02594	TIGR02594	TIGR02594 family protein
+PEP_exosort	TIGR02595	PEP-CTERM protein-sorting domain
+TIGR02596	TIGR02596	Verru_Chthon cassette protein D
+TIGR02597	TIGR02597	TIGR02597 family protein
+TIGR02598	TIGR02598	Verru_Chthon cassette protein B
+TIGR02599	TIGR02599	Verru_Chthon cassette protein C
+Verru_Chthon_A	TIGR02600	Verru_Chthon cassette protein A
+autotrns_rpt	TIGR02601	autotransporter-associated beta strand repeat
+8TM_EpsH	TIGR02602	exosortase
+CxxCH_TIGR02603	TIGR02603	putative heme-binding domain
+Piru_Ver_Nterm	TIGR02604	putative membrane-bound dehydrogenase domain
+CxxC_CxxC_SSSS	TIGR02605	putative regulatory protein, FmdB family
+antidote_CC2985	TIGR02606	putative addiction module antidote protein, CC2985 family
+antidote_HigA	TIGR02607	addiction module antidote protein, HigA family
+delta_60_rpt	TIGR02608	delta-60 repeat domain
+doc_partner	TIGR02609	putative addiction module antidote
+PHA_gran_rgn	TIGR02610	putative polyhydroxyalkanoic acid system protein
+TIGR02611	TIGR02611	TIGR02611 family protein
+mob_myst_A	TIGR02612	mobile mystery protein A
+mob_myst_B	TIGR02613	mobile mystery protein B
+ftsW	TIGR02614	cell division protein FtsW
+spoVE	TIGR02615	stage V sporulation protein E
+tnaC_leader	TIGR02616	tryptophanase leader peptide
+tnaA_trp_ase	TIGR02617	tryptophanase
+tyr_phenol_ly	TIGR02618	tyrosine phenol-lyase
+TIGR02619	TIGR02619	putative CRISPR-associated protein, APE2256 family
+cas_VVA1548	TIGR02620	putative CRISPR-associated protein, VVA1548 family
+cas3_GSU0051	TIGR02621	CRISPR-associated helicase Cas3, subtype Dpsyc
+CDP_4_6_dhtase	TIGR02622	CDP-glucose 4,6-dehydratase
+G1P_cyt_trans	TIGR02623	glucose-1-phosphate cytidylyltransferase
+rhamnu_1P_ald	TIGR02624	rhamnulose-1-phosphate aldolase
+YiiL_rotase	TIGR02625	L-rhamnose mutarotase
+rhamnulo_kin	TIGR02627	rhamnulokinase
+fuculo_kin_coli	TIGR02628	L-fuculokinase
+L_rham_iso_rhiz	TIGR02629	L-rhamnose catabolism isomerase
+xylose_isom_A	TIGR02630	xylose isomerase
+xylA_Arthro	TIGR02631	xylose isomerase
+RhaD_aldol-ADH	TIGR02632	rhamnulose-1-phosphate aldolase/alcohol dehydrogenase
+xylG	TIGR02633	D-xylose ABC transporter, ATP-binding protein
+xylF	TIGR02634	D-xylose ABC transporter, D-xylose-binding protein
+RhaI_grampos	TIGR02635	L-rhamnose isomerase
+galM_Leloir	TIGR02636	galactose mutarotase
+RhaS	TIGR02637	rhamnose ABC transporter, rhamnose-binding protein
+lactal_redase	TIGR02638	lactaldehyde reductase
+ClpA	TIGR02639	ATP-dependent Clp protease ATP-binding subunit ClpA
+gas_vesic_GvpN	TIGR02640	gas vesicle protein GvpN
+gvpC_cyan_rpt	TIGR02641	gas vesicle protein GvpC repeat
+phage_xxxx	TIGR02642	uncharacterized phage protein
+T_phosphoryl	TIGR02643	thymidine phosphorylase
+Y_phosphoryl	TIGR02644	pyrimidine-nucleoside phosphorylase
+ARCH_P_rylase	TIGR02645	putative thymidine phosphorylase
+TIGR02646	TIGR02646	TIGR02646 family protein
+DNA	TIGR02647	TIGR02647 family protein
+rep_term_tus	TIGR02648	DNA replication terminus site-binding protein
+true_RNase_BN	TIGR02649	ribonuclease BN
+RNase_Z_T_toga	TIGR02650	ribonuclease Z, Thermotoga type
+RNase_Z	TIGR02651	ribonuclease Z
+TIGR02652	TIGR02652	TIGR02652 family protein
+Lon_rel_chp	TIGR02653	conserved hypothetical protein
+circ_KaiB	TIGR02654	circadian clock protein KaiB
+circ_KaiC	TIGR02655	circadian clock protein KaiC
+cyanin_plasto	TIGR02656	plastocyanin
+amicyanin	TIGR02657	amicyanin
+TTQ_MADH_Hv	TIGR02658	methylamine dehydrogenase (amicyanin) heavy chain
+TTQ_MADH_Lt	TIGR02659	methylamine dehydrogenase (amicyanin) light chain
+nifV_homocitr	TIGR02660	homocitrate synthase
+MauD	TIGR02661	methylamine dehydrogenase accessory protein MauD
+dinitro_DRAG	TIGR02662	ADP-ribosyl-[dinitrogen reductase] hydrolase
+nifX	TIGR02663	nitrogen fixation protein NifX
+nitr_red_assoc	TIGR02664	conserved hypothetical protein
+molyb_mobA	TIGR02665	molybdenum cofactor guanylyltransferase
+moaA	TIGR02666	molybdenum cofactor biosynthesis protein A
+moaB_proteo	TIGR02667	molybdenum cofactor biosynthesis protein B
+moaA_archaeal	TIGR02668	probable molybdenum cofactor biosynthesis protein A
+SpoIID_LytB	TIGR02669	SpoIID/LytB domain
+cas_csx8	TIGR02670	CRISPR-associated protein Cas8a1/Csx8, subtype I
+cas_csx9	TIGR02671	CRISPR-associated protein Cas8a2/Csx9, subtype I-A/APERN
+cas_csm6	TIGR02672	CRISPR type III-A/MTUBE-associated protein Csm6
+FtsE	TIGR02673	cell division ATP-binding protein FtsE
+cas_cyan_RAMP_2	TIGR02674	CRISPR-associated RAMP protein, Csx10 family
+tape_meas_nterm	TIGR02675	tape measure domain
+TIGR02677	TIGR02677	TIGR02677 family protein
+TIGR02678	TIGR02678	TIGR02678 family protein
+TIGR02679	TIGR02679	TIGR02679 family protein
+TIGR02680	TIGR02680	TIGR02680 family protein
+phage_pRha	TIGR02681	phage regulatory protein, Rha family
+cas_csx11	TIGR02682	CRISPR-associated protein, Csx11 family
+upstrm_HI1419	TIGR02683	putative addiction module killer protein
+dnstrm_HI1420	TIGR02684	probable addiction module antidote protein
+pter_reduc_Leis	TIGR02685	pteridine reductase
+relax_trwC	TIGR02686	conjugative relaxase domain
+TIGR02687	TIGR02687	TIGR02687 family protein
+TIGR02688	TIGR02688	TIGR02688 family protein
+ars_reduc_gluta	TIGR02689	arsenate reductase, glutathione/glutaredoxin type
+resist_ArsH	TIGR02690	arsenical resistance protein ArsH
+arsC_pI258_fam	TIGR02691	arsenate reductase (thioredoxin)
+tRNA_CCA_actino	TIGR02692	CCA tRNA nucleotidyltransferase
+arsenite_ox_L	TIGR02693	arsenite oxidase, large subunit
+arsenite_ox_S	TIGR02694	arsenite oxidase, small subunit
+azurin	TIGR02695	azurin
+pppGpp_PNP	TIGR02696	guanosine pentaphosphate synthetase I/polyribonucleotide nucleotidyltransferase
+WPE_wolbac	TIGR02697	Wolbachia palindromic element domain
+CopY_TcrY	TIGR02698	copper transport repressor, CopY/TcrY family
+archaeo_AfpA	TIGR02699	archaeoflavoprotein AfpA
+flavo_MJ0208	TIGR02700	archaeoflavoprotein, MJ0208 family
+shell_carb_anhy	TIGR02701	carboxysome shell carbonic anhydrase
+SufR_cyano	TIGR02702	iron-sulfur cluster biosynthesis transcriptional regulator SufR
+carboxysome_A	TIGR02703	carboxysome peptide A
+carboxysome_B	TIGR02704	carboxysome peptide B
+nudix_YtkD	TIGR02705	nucleoside triphosphatase YtkD
+P_butyryltrans	TIGR02706	phosphate butyryltransferase
+butyr_kinase	TIGR02707	butyrate kinase
+L_lactate_ox	TIGR02708	L-lactate oxidase
+branched_ptb	TIGR02709	branched-chain phosphotransacylase
+TIGR02710	TIGR02710	CRISPR-associated protein, TIGR02710 family
+symport_actP	TIGR02711	cation/acetate symporter ActP
+urea_carbox	TIGR02712	urea carboxylase
+allophanate_hyd	TIGR02713	allophanate hydrolase
+amido_AtzD_TrzD	TIGR02714	ring-opening amidohydrolases
+amido_AtzE	TIGR02715	amidohydrolase, AtzE family
+C20_methyl_CrtF	TIGR02716	C-20 methyltransferase BchU
+AcCoA-syn-alpha	TIGR02717	acetyl coenzyme A synthetase (ADP forming), alpha domain
+sider_RhtX_FptX	TIGR02718	siderophore transporter, RhtX/FptX family
+repress_PhaQ	TIGR02719	poly-beta-hydroxybutyrate-responsive repressor
+pyruv_oxi_spxB	TIGR02720	pyruvate oxidase
+ycfN_thiK	TIGR02721	thiamine kinase
+lp_	TIGR02722	uncharacterized lipoprotein
+phenyl_P_alpha	TIGR02723	phenylphosphate carboxylase, alpha subunit
+phenyl_P_beta	TIGR02724	phenylphosphate carboxylase, beta subunit
+phenyl_P_gamma	TIGR02725	phenylphosphate carboxylase, gamma subunit
+phenyl_P_delta	TIGR02726	phenylphosphate carboxylase, delta subunit
+MTHFS_bact	TIGR02727	5-formyltetrahydrofolate cyclo-ligase
+spore_gerQ	TIGR02728	spore coat protein GerQ
+Obg_CgtA	TIGR02729	Obg family GTPase CgtA
+carot_isom	TIGR02730	carotene isomerase
+phytoene_desat	TIGR02731	phytoene desaturase
+zeta_caro_desat	TIGR02732	9,9'-di-cis-zeta-carotene desaturase
+desat_CrtD	TIGR02733	C-3',4' desaturase CrtD
+crtI_fam	TIGR02734	phytoene desaturase
+purC_vibrio	TIGR02735	phosphoribosylaminoimidazole-succinocarboxamide synthase
+cbb3_Q_epsi	TIGR02736	cytochrome c oxidase, cbb3-type, CcoQ subunit
+caa3_CtaG	TIGR02737	cytochrome c oxidase assembly factor CtaG
+TrbB	TIGR02738	type-F conjugative transfer system pilin assembly thiol-disulfide isomerase TrbB
+TraF	TIGR02739	type-F conjugative transfer system pilin assembly protein TraF
+TraF-like	TIGR02740	TraF-like protein
+TraQ	TIGR02741	type-F conjugative transfer system pilin chaperone TraQ
+TrbC_Ftype	TIGR02742	type-F conjugative transfer system pilin assembly protein TrbC
+TraW	TIGR02743	type-F conjugative transfer system protein TraW
+TrbI_Ftype	TIGR02744	type-F conjugative transfer system protein TrbI
+ccoG_rdxA_fixG	TIGR02745	cytochrome c oxidase accessory protein CcoG
+TraC-F-type	TIGR02746	type-IV secretion system protein TraC
+TraV	TIGR02747	type IV conjugative transfer system protein TraV
+GerC3_HepT	TIGR02748	heptaprenyl diphosphate synthase component II
+prenyl_cyano	TIGR02749	solanesyl diphosphate synthase
+TraN_Ftype	TIGR02750	type-F conjugative transfer system mating-pair stabilization protein TraN
+PEPCase_arch	TIGR02751	phosphoenolpyruvate carboxylase
+MenG_heptapren	TIGR02752	demethylmenaquinone methyltransferase
+sodN	TIGR02753	superoxide dismutase, Ni
+sod_Ni_protease	TIGR02754	nickel-type superoxide dismutase maturation protease
+TraX_Ftype	TIGR02755	type-F conjugative transfer system pilin acetylase TraX
+TraK_Ftype	TIGR02756	type-F conjugative transfer system secretin TraK
+TIGR02757	TIGR02757	TIGR02757 family protein
+TraA_TIGR	TIGR02758	type IV conjugative transfer system pilin TraA
+TraD_Ftype	TIGR02759	type IV conjugative transfer system coupling protein TraD
+TraI_TIGR	TIGR02760	conjugative transfer relaxase protein TraI
+TraE_TIGR	TIGR02761	type IV conjugative transfer system protein TraE
+TraL_TIGR	TIGR02762	type IV conjugative transfer system protein TraL
+chlamy_scaf	TIGR02763	scaffolding protein
+spore_ybaN_pdaB	TIGR02764	polysaccharide deacetylase family sporulation protein PdaB
+crypto_DASH	TIGR02765	cryptochrome, DASH family
+crypt_chrom_pln	TIGR02766	cryptochrome, plant family
+TraG-Ti	TIGR02767	Ti-type conjugative transfer system protein TraG
+TraA_Ti	TIGR02768	Ti-type conjugative transfer relaxase TraA
+nickel_nikE	TIGR02769	nickel import ATP-binding protein NikE
+nickel_nikD	TIGR02770	nickel import ATP-binding protein NikD
+TraF_Ti	TIGR02771	conjugative transfer signal peptidase TraF
+Ku_bact	TIGR02772	Ku protein
+addB_Gpos	TIGR02773	helicase-exonuclease AddAB, AddB subunit
+rexB_recomb	TIGR02774	ATP-dependent nuclease subunit B
+TrbG_Ti	TIGR02775	P-type conjugative transfer protein TrbG
+NHEJ_ligase_prk	TIGR02776	DNA ligase D
+LigD_PE_dom	TIGR02777	DNA ligase D, 3'-phosphoesterase domain
+ligD_pol	TIGR02778	DNA ligase D, polymerase domain
+NHEJ_ligase_lig	TIGR02779	DNA ligase D, ligase domain
+TrbJ_Ti	TIGR02780	P-type conjugative transfer protein TrbJ
+VirB9	TIGR02781	P-type conjugative transfer protein VirB9
+TrbB_P	TIGR02782	P-type conjugative transfer ATPase TrbB
+TrbL_P	TIGR02783	P-type conjugative transfer protein TrbL
+addA_alphas	TIGR02784	double-strand break repair helicase AddA
+addA_Gpos	TIGR02785	helicase-exonuclease AddAB, AddA subunit
+addB_alphas	TIGR02786	double-strand break repair protein AddB
+codY_Gpos	TIGR02787	GTP-sensing transcriptional pleiotropic repressor CodY
+VirB11	TIGR02788	P-type DNA transfer ATPase VirB11
+nickel_nikB	TIGR02789	nickel ABC transporter, permease subunit NikB
+nickel_nikC	TIGR02790	nickel ABC transporter, permease subunit NikC
+VirB5	TIGR02791	P-type DNA transfer protein VirB5
+PCA_ligA	TIGR02792	protocatechuate 4,5-dioxygenase, alpha subunit
+nikR	TIGR02793	nickel-responsive transcriptional regulator NikR
+tolA_full	TIGR02794	protein TolA
+tol_pal_ybgF	TIGR02795	tol-pal system protein YbgF
+tolQ	TIGR02796	protein TolQ
+exbB	TIGR02797	tonB-system energizer ExbB
+ligK_PcmE	TIGR02798	4-carboxy-4-hydroxy-2-oxoadipate aldolase/oxaloacetate decarboxylase
+thio_ybgC	TIGR02799	tol-pal system-associated acyl-CoA thioesterase
+propeller_TolB	TIGR02800	Tol-Pal system beta propeller repeat protein TolB
+tolR	TIGR02801	protein TolR
+Pal_lipo	TIGR02802	peptidoglycan-associated lipoprotein
+ExbD_1	TIGR02803	TonB system transport protein ExbD
+ExbD_2	TIGR02804	TonB system transport protein ExbD
+exbB2	TIGR02805	tonB-system energizer ExbB
+clostrip	TIGR02806	clostripain
+cas6_cmx6	TIGR02807	CRISPR-associated protein Cas6, subtype MYXAN
+short_TIGR02808	TIGR02808	TIGR02808 family protein
+phasin_3	TIGR02809	phasin family protein
+agaZ_gatZ	TIGR02810	D-tagatose-bisphosphate aldolase, class II, non-catalytic subunit
+formate_TAT	TIGR02811	formate dehydrogenase region TAT target
+fadR_gamma	TIGR02812	fatty acid metabolism transcriptional regulator FadR
+omega_3_PfaA	TIGR02813	polyketide-type polyunsaturated fatty acid synthase PfaA
+pfaD_fam	TIGR02814	PfaD family protein
+agaS_fam	TIGR02815	putative sugar isomerase, AgaS family
+pfaB_fam	TIGR02816	PfaB family protein
+adh_fam_1	TIGR02817	zinc-binding alcohol dehydrogenase family protein
+adh_III_F_hyde	TIGR02818	S-(hydroxymethyl)glutathione dehydrogenase/class III alcohol dehydrogenase
+fdhA_non_GSH	TIGR02819	formaldehyde dehydrogenase, glutathione-independent
+formald_GSH	TIGR02820	S-(hydroxymethyl)glutathione synthase
+fghA_ester_D	TIGR02821	S-formylglutathione hydrolase
+adh_fam_2	TIGR02822	zinc-binding alcohol dehydrogenase family protein
+oxido_YhdH	TIGR02823	putative quinone oxidoreductase, YhdH/YhfP family
+quinone_pig3	TIGR02824	putative NAD(P)H quinone oxidoreductase, PIG3 family
+B4_12hDH	TIGR02825	leukotriene B4 12-hydroxydehydrogenase/15-oxo-prostaglandin 13-reductase
+RNR_activ_nrdG3	TIGR02826	anaerobic ribonucleoside-triphosphate reductase activating protein
+RNR_anaer_Bdell	TIGR02827	anaerobic ribonucleoside-triphosphate reductase
+TIGR02828	TIGR02828	putative membrane fusion protein
+spore_III_AE	TIGR02829	stage III sporulation protein AE
+spore_III_AG	TIGR02830	stage III sporulation protein AG
+spo_II_M	TIGR02831	stage II sporulation protein M
+spo_yunB	TIGR02832	sporulation protein YunB
+spore_III_AB	TIGR02833	stage III sporulation protein AB
+spo_ytxC	TIGR02834	putative sporulation protein YtxC
+spore_sigmaE	TIGR02835	RNA polymerase sigma-E factor
+spore_IV_A	TIGR02836	stage IV sporulation protein A
+spore_II_R	TIGR02837	stage II sporulation protein R
+spore_V_AC	TIGR02838	stage V sporulation protein AC
+spore_V_AE	TIGR02839	stage V sporulation protein AE
+spore_YtaF	TIGR02840	putative sporulation protein YtaF
+spore_YyaC	TIGR02841	putative sporulation protein YyaC
+CyoC	TIGR02842	cytochrome o ubiquinol oxidase, subunit III
+CyoB	TIGR02843	cytochrome o ubiquinol oxidase, subunit I
+spore_III_D	TIGR02844	sporulation transcriptional regulator SpoIIID
+spore_V_AD	TIGR02845	stage V sporulation protein AD
+spore_sigmaK	TIGR02846	RNA polymerase sigma-K factor
+CyoD	TIGR02847	cytochrome o ubiquinol oxidase subunit IV
+spore_III_AC	TIGR02848	stage III sporulation protein AC
+spore_III_AD	TIGR02849	stage III sporulation protein AD
+spore_sigG	TIGR02850	RNA polymerase sigma-G factor
+spore_V_T	TIGR02851	stage V sporulation protein T
+spore_dpaB	TIGR02852	dipicolinic acid synthetase, B subunit
+spore_dpaA	TIGR02853	dipicolinic acid synthetase, A subunit
+spore_II_GA	TIGR02854	sigma-E processing peptidase SpoIIGA
+spore_yabG	TIGR02855	sporulation peptidase YabG
+spore_yqfC	TIGR02856	sporulation protein YqfC
+CydD	TIGR02857	thiol reductant ABC exporter, CydD subunit
+spore_III_AA	TIGR02858	stage III sporulation protein AA
+spore_sigH	TIGR02859	RNA polymerase sigma-H factor
+spore_IV_B	TIGR02860	stage IV sporulation protein B
+SASP_H	TIGR02861	small acid-soluble spore protein, H-type
+spore_BofA	TIGR02862	pro-sigmaK processing inhibitor BofA
+spore_sspJ	TIGR02863	small, acid-soluble spore protein, SspJ family
+spore_sspO	TIGR02864	small, acid-soluble spore protein O
+spore_II_E	TIGR02865	stage II sporulation protein E
+CoxB	TIGR02866	cytochrome c oxidase, subunit II
+spore_II_P	TIGR02867	stage II sporulation protein P
+CydC	TIGR02868	thiol reductant ABC exporter, CydC subunit
+spore_SleB	TIGR02869	spore cortex-lytic enzyme
+spore_II_D	TIGR02870	stage II sporulation protein D
+spore_ylbJ	TIGR02871	sporulation integral membrane protein YlbJ
+spore_ytvI	TIGR02872	sporulation integral membrane protein YtvI
+spore_ylxY	TIGR02873	probable sporulation protein, polysaccharide deacetylase family
+spore_ytfJ	TIGR02874	sporulation protein YtfJ
+spore_0_A	TIGR02875	sporulation transcription factor Spo0A
+spore_yqfD	TIGR02876	sporulation protein YqfD
+spore_yhbH	TIGR02877	sporulation protein YhbH
+spore_ypjB	TIGR02878	sporulation protein YpjB
+cbbX_cfxQ	TIGR02880	CbbX protein
+spore_V_K	TIGR02881	stage V sporulation protein K
+QoxB	TIGR02882	cytochrome aa3 quinol oxidase, subunit I
+spore_cwlD	TIGR02883	N-acetylmuramoyl-L-alanine amidase CwlD
+spore_pdaA	TIGR02884	delta-lactam-biosynthetic de-N-acetylase
+spore_sigF	TIGR02885	RNA polymerase sigma-F factor
+spore_II_AA	TIGR02886	anti-sigma F factor antagonist
+spore_ger_x_C	TIGR02887	germination protein, Ger(x)C family
+spore_YlmC_YmxH	TIGR02888	sporulation protein, YlmC/YmxH family
+spore_YpeB	TIGR02889	germination protein YpeB
+bacill_yteA	TIGR02890	regulatory protein, yteA family
+CtaD_CoxA	TIGR02891	cytochrome c oxidase, subunit I
+spore_yabP	TIGR02892	sporulation protein YabP
+spore_yabQ	TIGR02893	spore cortex biosynthesis protein YabQ
+DNA_bind_RsfA	TIGR02894	transcription factor, RsfA family
+spore_sigI	TIGR02895	RNA polymerase sigma-I factor
+spore_III_AF	TIGR02896	stage III sporulation protein AF
+QoxC	TIGR02897	cytochrome aa3 quinol oxidase, subunit III
+spore_YhcN_YlaJ	TIGR02898	sporulation lipoprotein, YhcN/YlaJ family
+spore_safA	TIGR02899	spore coat assembly protein SafA
+spore_V_B	TIGR02900	stage V sporulation protein B
+QoxD	TIGR02901	cytochrome aa3 quinol oxidase, subunit IV
+spore_lonB	TIGR02902	ATP-dependent protease LonB
+spore_lon_C	TIGR02903	ATP-dependent protease, Lon family
+spore_ysxE	TIGR02904	spore coat protein YsxE
+spore_yutH	TIGR02905	spore coat protein YutH
+spore_CotS	TIGR02906	spore coat protein, CotS family
+spore_VI_D	TIGR02907	stage VI sporulation protein D
+CoxD_Bacillus	TIGR02908	cytochrome c oxidase, subunit IVB
+spore_YkwD	TIGR02909	uncharacterized protein, YkwD family
+sulfite_red_A	TIGR02910	sulfite reductase, subunit A
+sulfite_red_B	TIGR02911	sulfite reductase, subunit B
+sulfite_red_C	TIGR02912	sulfite reductase, subunit C
+HAF_rpt	TIGR02913	probable extracellular repeat, HAF family
+EpsI_fam	TIGR02914	EpsI family protein
+PEP_resp_reg	TIGR02915	PEP-CTERM-box response regulator transcription factor
+PEP_his_kin	TIGR02916	putative PEP-CTERM system histidine kinase
+PEP_TPR_lipo	TIGR02917	putative PEP-CTERM system TPR-repeat lipoprotein
+TIGR02918	TIGR02918	accessory Sec system glycosylation protein GtfA
+TIGR02919	TIGR02919	accessory Sec system glycosyltransferase GtfB
+acc_sec_Y2	TIGR02920	accessory Sec system translocase SecY2
+PEP_integral	TIGR02921	PEP-CTERM family integral membrane protein
+TIGR02922	TIGR02922	TIGR02922 family protein
+AhaC	TIGR02923	ATP synthase A1, C subunit
+ICDH_alpha	TIGR02924	isocitrate dehydrogenase
+cis_trans_EpsD	TIGR02925	peptidyl-prolyl cis-trans isomerase, EpsD family
+AhaH	TIGR02926	ATP synthase archaeal, H subunit
+SucB_Actino	TIGR02927	2-oxoglutarate dehydrogenase, E2 component, dihydrolipoamide succinyltransferase
+TIGR02928	TIGR02928	orc1/cdc6 family replication initiation protein
+anfG_nitrog	TIGR02929	Fe-only nitrogenase, delta subunit
+vnfG_nitrog	TIGR02930	V-containing nitrogenase, delta subunit
+anfK_nitrog	TIGR02931	Fe-only nitrogenase, beta subunit
+vnfK_nitrog	TIGR02932	V-containing nitrogenase, beta subunit
+nifM_nitrog	TIGR02933	nitrogen fixation protein NifM
+nifT_nitrog	TIGR02934	probable nitrogen fixation protein FixT
+TIGR02935	TIGR02935	probable nitrogen fixation protein
+fdxN_nitrog	TIGR02936	ferredoxin III, nif-specific
+sigma70-ECF	TIGR02937	RNA polymerase sigma factor, sigma-70 family
+nifL_nitrog	TIGR02938	nitrogen fixation negative regulator NifL
+RpoE_Sigma70	TIGR02939	RNA polymerase sigma factor RpoE
+anfO_nitrog	TIGR02940	Fe-only nitrogenase accessory protein AnfO
+Sigma_B	TIGR02941	RNA polymerase sigma-B factor
+Sig70_famx1	TIGR02943	RNA polymerase sigma-70 factor, TIGR02943 family
+suf_reg_Xantho	TIGR02944	FeS assembly SUF system regulator
+SUF_assoc	TIGR02945	FeS assembly SUF system protein
+acyl_WS_DGAT	TIGR02946	acyltransferase, WS/DGAT/MGAT
+SigH_actino	TIGR02947	RNA polymerase sigma-70 factor, TIGR02947 family
+SigW_bacill	TIGR02948	RNA polymerase sigma-W factor
+anti_SigH_actin	TIGR02949	anti-sigma factor, TIGR02949 family
+SigM_subfam	TIGR02950	RNA polymerase sigma factor, SigM family
+DMSO_dmsB	TIGR02951	dimethylsulfoxide reductase, chain B
+Sig70_famx2	TIGR02952	RNA polymerase sigma-70 factor, TIGR02952 family
+penta_MxKDx	TIGR02953	pentapeptide MXKDX repeat protein
+Sig70_famx3	TIGR02954	RNA polymerase sigma-70 factor, TIGR02954 family
+TMAO_TorT	TIGR02955	TMAO reductase system periplasmic protein TorT
+TMAO_torS	TIGR02956	TMAO reductase sytem sensor TorS
+SigX4	TIGR02957	RNA polymerase sigma-70 factor, TIGR02957 family
+SigZ	TIGR02959	RNA polymerase sigma factor, SigZ family
+SigX5	TIGR02960	RNA polymerase sigma-70 factor, TIGR02960 family
+allantoicase	TIGR02961	allantoicase
+hdxy_isourate	TIGR02962	hydroxyisourate hydrolase
+xanthine_xdhA	TIGR02963	xanthine dehydrogenase, small subunit
+xanthine_xdhC	TIGR02964	xanthine dehydrogenase accessory protein XdhC
+xanthine_xdhB	TIGR02965	xanthine dehydrogenase, molybdopterin binding subunit
+phoR_proteo	TIGR02966	phosphate regulon sensor kinase PhoR
+guan_deamin	TIGR02967	guanine deaminase
+succ_dehyd_anc	TIGR02968	succinate dehydrogenase, hydrophobic membrane anchor protein
+mam_aldehyde_ox	TIGR02969	aldehyde oxidase
+succ_dehyd_cytB	TIGR02970	succinate dehydrogenase, cytochrome b556 subunit
+heterocyst_DevB	TIGR02971	ABC exporter membrane fusion protein, DevB family
+TMAO_torE	TIGR02972	trimethylamine N-oxide reductase system, TorE protein
+nitrate_rd_NapE	TIGR02973	periplasmic nitrate reductase, NapE protein
+phageshock_pspF	TIGR02974	psp operon transcriptional activator
+phageshock_pspG	TIGR02975	phage shock protein G
+phageshock_pspB	TIGR02976	phage shock protein B
+phageshock_pspA	TIGR02977	phage shock protein A
+phageshock_pspC	TIGR02978	phage shock protein C
+phageshock_pspD	TIGR02979	phage shock protein PspD
+SigBFG	TIGR02980	RNA polymerase sigma-70 factor, sigma-B/F/G subfamily
+phageshock_pspE	TIGR02981	phage shock operon rhodanese PspE
+heterocyst_DevA	TIGR02982	ABC exporter ATP-binding subunit, DevA family
+SigE-fam_strep	TIGR02983	RNA polymerase sigma-70 factor, sigma-E family
+Sig-70_plancto1	TIGR02984	RNA polymerase sigma-70 factor, Planctomycetaceae-specific subfamily 1
+Sig70_bacteroi1	TIGR02985	RNA polymerase sigma-70 factor, Bacteroides expansion family 1
+restrict_Alw26I	TIGR02986	type II restriction endonuclease, Alw26I/Eco31I/Esp3I family
+met_A_Alw26	TIGR02987	type II restriction m6 adenine DNA methyltransferase, Alw26I/Eco31I/Esp3I family
+YaaA_near_RecF	TIGR02988	S4 domain protein YaaA
+Sig-70_gvs1	TIGR02989	RNA polymerase sigma-70 factor, Rhodopirellula/Verrucomicrobium family
+ectoine_eutA	TIGR02990	ectoine utilization protein EutA
+ectoine_eutB	TIGR02991	ectoine utilization protein EutB
+ectoine_eutC	TIGR02992	ectoine utilization protein EutC
+ectoine_eutD	TIGR02993	ectoine utilization protein EutD
+ectoine_eutE	TIGR02994	ectoine utilization protein EutE
+ectoine_ehuB	TIGR02995	ectoine/hydroxyectoine ABC transporter solute-binding protein EhuB
+rpt_mate_G_obs	TIGR02996	repeat-companion domain TIGR02996
+Sig70-cyanoRpoD	TIGR02997	RNA polymerase sigma factor, cyanobacterial RpoD-like family
+RraA_entero	TIGR02998	regulator of ribonuclease activity A
+Sig-70_X6	TIGR02999	RNA polymerase sigma factor, TIGR02999 family
+plancto_dom_1	TIGR03000	Planctomycetes uncharacterized domain TIGR03000
+Sig-70_gmx1	TIGR03001	RNA polymerase sigma-70 factor, Myxococcales family 1
+outer_YhbN_LptA	TIGR03002	lipopolysaccharide transport periplasmic protein LptA
+ectoine_ehuD	TIGR03003	ectoine/hydroxyectoine ABC transporter, permease protein EhuD
+ectoine_ehuC	TIGR03004	ectoine/hydroxyectoine ABC transporter, permease protein EhuC
+ectoine_ehuA	TIGR03005	ectoine/hydroxyectoine ABC transporter, ATP-binding protein EhuA
+pepcterm_polyde	TIGR03006	polysaccharide deacetylase family protein, PEP-CTERM locus subfamily
+pepcterm_ChnLen	TIGR03007	polysaccharide chain length determinant protein, PEP-CTERM locus subfamily
+pepcterm_CAAX	TIGR03008	CAAX prenyl protease-related protein
+plancto_dom_2	TIGR03009	Planctomycetes uncharacterized domain TIGR03009
+sulf_tusC_dsrF	TIGR03010	sulfur relay protein TusC/DsrF
+sulf_tusB_dsrH	TIGR03011	sulfur relay protein TusB/DsrH
+sulf_tusD_dsrE	TIGR03012	sulfur relay protein TusD/DsrE
+EpsB_2	TIGR03013	sugar transferase, PEP-CTERM system associated
+EpsL	TIGR03014	exopolysaccharide biosynthesis operon protein EpsL
+pepcterm_ATPase	TIGR03015	putative secretion ATPase, PEP-CTERM locus subfamily
+pepcterm_hypo_1	TIGR03016	uncharacterized protein, PEP-CTERM system associated
+EpsF	TIGR03017	chain length determinant protein EpsF
+pepcterm_TyrKin	TIGR03018	exopolysaccharide/PEP-CTERM locus tyrosine autokinase
+pepcterm_femAB	TIGR03019	FemAB-related protein, PEP-CTERM system-associated
+EpsA	TIGR03020	transcriptional regulator EpsA
+pilP_fam	TIGR03021	type IV pilus biogenesis protein PilP
+WbaP_sugtrans	TIGR03022	undecaprenyl-phosphate galactose phosphotransferase WbaP
+WcaJ_sugtrans	TIGR03023	undecaprenyl-phosphate glucose phosphotransferase
+arch_PEF_CTERM	TIGR03024	PEF-CTERM protein sorting domain
+EPS_sugtrans	TIGR03025	exopolysaccharide biosynthesis polyprenyl glycosylphosphotransferase
+NDP-sugDHase	TIGR03026	nucleotide sugar dehydrogenase
+pepcterm_export	TIGR03027	putative polysaccharide export protein, PEP-CTERM sytem-associated
+EpsE	TIGR03028	polysaccharide export protein EpsE
+EpsG	TIGR03029	chain length determinant protein tyrosine kinase EpsG
+CelA	TIGR03030	cellulose synthase catalytic subunit (UDP-forming)
+cas_csx12	TIGR03031	CRISPR system subtype II-B RNA-guided endonuclease Cas9/Csx12
+TIGR03032	TIGR03032	TIGR03032 family protein
+phage_rel_nuc	TIGR03033	putative phage-type endonuclease
+TIGR03034	TIGR03034	conserved hypothetical protein
+trp_arylform	TIGR03035	arylformamidase
+trp_2_3_diox	TIGR03036	tryptophan 2,3-dioxygenase
+anthran_nbaC	TIGR03037	3-hydroxyanthranilate 3,4-dioxygenase
+PS_II_psbM	TIGR03038	photosystem II reaction center protein PsbM
+PS_II_CP47	TIGR03039	photosystem II chlorophyll-binding protein CP47
+PS_antenn_a_b	TIGR03041	chlorophyll a/b binding light-harvesting protein
+PS_II_psbQ_bact	TIGR03042	photosystem II protein PsbQ
+PS_II_psbZ	TIGR03043	photosystem II core protein PsbZ
+PS_II_psb27	TIGR03044	photosystem II protein Psb27
+PS_II_C550	TIGR03045	cytochrome c-550
+PS_II_psbV2	TIGR03046	photosystem II cytochrome PsbV2
+PS_II_psb28	TIGR03047	photosystem II reaction center protein Psb28
+PS_I_psaC	TIGR03048	photosystem I iron-sulfur protein PsaC
+PS_I_psaK	TIGR03049	photosystem I reaction center subunit PsaK
+PS_I_psaK_plant	TIGR03050	photosystem I reaction center PsaK
+PS_I_psaG_plant	TIGR03051	photosystem I reaction center subunit V
+PS_I_psaI	TIGR03052	photosystem I reaction center subunit VIII
+PS_I_psaM	TIGR03053	photosystem I reaction center subunit XII
+photo_alph_chp1	TIGR03054	putative photosynthetic complex assembly protein
+photo_alph_chp2	TIGR03055	putative photosynthetic complex assembly protein 2
+bchO_mg_che_rel	TIGR03056	putative magnesium chelatase accessory protein
+xxxLxxG_by_4	TIGR03057	X-X-X-Leu-X-X-Gly heptad repeats
+rpt_csmH	TIGR03058	chlorosome envelope protein H
+psaOeuk	TIGR03059	photosystem I protein PsaO
+PS_II_psb29	TIGR03060	photosystem II biogenesis protein Psp29
+pip_yhgE_Nterm	TIGR03061	YhgE/Pip N-terminal domain
+pip_yhgE_Cterm	TIGR03062	YhgE/Pip C-terminal domain
+srtB_target	TIGR03063	sortase B cell surface sorting signal
+sortase_srtB	TIGR03064	sortase, SrtB family
+srtB_sig_QVPTGV	TIGR03065	sortase B signal domain, QVPTGV class
+Gem_osc_para_1	TIGR03066	Gemmata obscuriglobus paralogous family TIGR03066
+Planc_TIGR03067	TIGR03067	Planctomycetes uncharacterized domain TIGR03067
+srtB_sig_NPQTN	TIGR03068	sortase B signal domain, NPQTN class
+PS_II_S4	TIGR03069	photosystem II S4 domain protein
+couple_hipB	TIGR03070	transcriptional regulator, y4mF family
+couple_hipA	TIGR03071	HipA N-terminal domain
+release_prfH	TIGR03072	putative peptide chain release factor H
+release_rtcB	TIGR03073	release factor H-coupled RctB family protein
+PQQ_membr_DH	TIGR03074	membrane-bound PQQ-dependent dehydrogenase, glucose/quinate/shikimate family
+PQQ_enz_alc_DH	TIGR03075	PQQ-dependent dehydrogenase, methanol/ethanol family
+near_not_gcvH	TIGR03076	chlamydial GcvH-like protein upstream region protein
+not_gcvH	TIGR03077	glycine cleavage protein H-like protein
+CH4_NH3mon_ox_C	TIGR03078	methane monooxygenase/ammonia monooxygenase, subunit C
+CH4_NH3mon_ox_B	TIGR03079	methane monooxygenase/ammonia monooxygenase, subunit B
+CH4_NH3mon_ox_A	TIGR03080	methane monooxygenase/ammonia monooxygenase, subunit A
+metmalonyl_epim	TIGR03081	methylmalonyl-CoA epimerase
+Gneg_AbrB_dup	TIGR03082	membrane protein AbrB duplication
+TIGR03083	TIGR03083	uncharacterized Actinobacterial protein TIGR03083
+TIGR03084	TIGR03084	TIGR03084 family protein
+TIGR03085	TIGR03085	TIGR03085 family protein
+TIGR03086	TIGR03086	TIGR03086 family protein
+stp1	TIGR03087	sugar transferase, PEP-CTERM/EpsH1 system associated
+stp2	TIGR03088	sugar transferase, PEP-CTERM/EpsH1 system associated
+TIGR03089	TIGR03089	TIGR03089 family protein
+SASP_tlp	TIGR03090	small, acid-soluble spore protein tlp
+SASP_sspK	TIGR03091	small, acid-soluble spore protein K
+SASP_sspI	TIGR03092	small, acid-soluble spore protein I
+SASP_sspL	TIGR03093	small, acid-soluble spore protein L
+sulfo_cyanin	TIGR03094	sulfocyanin
+rusti_cyanin	TIGR03095	rusticyanin
+nitroso_cyanin	TIGR03096	nitrosocyanin
+PEP_O_lig_1	TIGR03097	probable O-glycosylation ligase, exosortase A-associated
+ligase_PEP_1	TIGR03098	acyl-CoA ligase (AMP-forming), exosortase A-associated
+dCO2ase_PEP1	TIGR03099	pyridoxal-dependent decarboxylase, exosortase A system-associated
+hydr1_PEP	TIGR03100	exosortase A system-associated hydrolase 1
+hydr2_PEP	TIGR03101	exosortase A system-associated hydrolase 2
+halo_cynanin	TIGR03102	halocyanin domain
+trio_acet_GNAT	TIGR03103	GNAT-family acetyltransferase TIGR03103
+trio_amidotrans	TIGR03104	asparagine synthase family amidotransferase
+gln_synth_III	TIGR03105	glutamine synthetase, type III
+trio_M42_hydro	TIGR03106	hydrolase, peptidase M42 family
+glu_aminopep	TIGR03107	glutamyl aminopeptidase
+eps_aminotran_1	TIGR03108	exosortase A system-associated amidotransferase 1
+exosortase_1	TIGR03109	exosortase A
+exosort_Gpos	TIGR03110	exosortase family protein XrtG
+glyc2_xrt_Gpos1	TIGR03111	putative glycosyltransferase, exosortase G-associated
+6_pyr_pter_rel	TIGR03112	6-pyruvoyl tetrahydropterin synthase-related domain
+exosortase_2	TIGR03113	exosortase B
+cas8u_csf1	TIGR03114	CRISPR type AFERR-associated protein Csf1
+cas7_csf2	TIGR03115	CRISPR type IV/AFERR-associated protein Csf2
+cas5_csf3	TIGR03116	CRISPR type IV/AFERR-associated protein Csf3
+cas_csf4	TIGR03117	CRISPR type AFERR-associated DEAD/DEAH-box helicase Csf4
+PEPCTERM_chp_1	TIGR03118	TIGR03118 family protein
+one_C_fhcD	TIGR03119	formylmethanofuran--tetrahydromethanopterin N-formyltransferase
+one_C_mch	TIGR03120	methenyltetrahydromethanopterin cyclohydrolase
+one_C_dehyd_A	TIGR03121	formylmethanofuran dehydrogenase subunit A
+one_C_dehyd_C	TIGR03122	formylmethanofuran dehydrogenase subunit C
+one_C_unchar_1	TIGR03123	probable H4MPT-linked C1 transfer pathway protein
+citrate_citX	TIGR03124	holo-ACP synthase CitX
+citrate_citG	TIGR03125	triphosphoribosyl-dephospho-CoA synthase CitG
+one_C_fae	TIGR03126	formaldehyde-activating enzyme
+RuMP_HxlB	TIGR03127	6-phospho 3-hexuloisomerase
+RuMP_HxlA	TIGR03128	3-hexulose-6-phosphate synthase
+one_C_dehyd_B	TIGR03129	formylmethanofuran dehydrogenase subunit B
+malonate_delta	TIGR03130	malonate decarboxylase acyl carrier protein
+malonate_mdcH	TIGR03131	malonate decarboxylase, epsilon subunit
+malonate_mdcB	TIGR03132	triphosphoribosyl-dephospho-CoA synthase MdcB
+malonate_beta	TIGR03133	biotin-independent malonate decarboxylase, beta subunit
+malonate_gamma	TIGR03134	biotin-independent malonate decarboxylase, gamma subunit
+malonate_mdcG	TIGR03135	malonate decarboxylase holo-[acyl-carrier-protein] synthase
+malonate_biotin	TIGR03136	Na+-transporting malonate decarboxylase, carboxybiotin decarboxylase subunit
+AhpC	TIGR03137	peroxiredoxin
+QueF	TIGR03138	queuine synthase
+QueF-II	TIGR03139	7-cyano-7-deazaguanine reductase
+AhpF	TIGR03140	alkyl hydroperoxide reductase subunit F
+cytochro_ccmD	TIGR03141	heme exporter protein CcmD
+cytochro_ccmI	TIGR03142	cytochrome c-type biogenesis protein CcmI
+AhpF_homolog	TIGR03143	putative alkyl hydroperoxide reductase F subunit
+cytochr_II_ccsB	TIGR03144	cytochrome c-type biogenesis protein CcsB
+cyt_nit_nrfE	TIGR03145	cytochrome c nitrate reductase biogenesis protein NrfE
+cyt_nit_nrfB	TIGR03146	cytochrome c nitrite reductase, pentaheme subunit
+cyt_nit_nrfF	TIGR03147	cytochrome c nitrite reductase, accessory protein NrfF
+cyt_nit_nrfD	TIGR03148	cytochrome c nitrite reductase, NrfD subunit
+cyt_nit_nrfC	TIGR03149	cytochrome c nitrite reductase, Fe-S protein
+fabF	TIGR03150	beta-ketoacyl-acyl-carrier-protein synthase II
+enACPred_II	TIGR03151	putative enoyl-[acyl-carrier-protein] reductase II
+cyto_c552_HCOOH	TIGR03152	formate-dependent cytochrome c nitrite reductase, c552 subunit
+cytochr_NrfH	TIGR03153	cytochrome c nitrite reductase, small subunit
+sulfolob_CbsA	TIGR03154	cytochrome b558/566, subunit A
+sulfolob_CbsB	TIGR03155	cytochrome b558/566, subunit B
+GTP_HflX	TIGR03156	GTP-binding protein HflX
+cas_Csc2	TIGR03157	CRISPR type I-D/CYANO-associated protein Csc2
+cas3_cyano	TIGR03158	CRISPR-associated helicase Cas3, subtype CYANO
+cas_Csc1	TIGR03159	CRISPR type I-D/CYANO-associated protein Csc1
+cobT_DBIPRT	TIGR03160	nicotinate-nucleotide--dimethylbenzimidazole phosphoribosyltransferase
+ribazole_CobZ	TIGR03161	alpha-ribazole phosphatase CobZ
+ribazole_cobC	TIGR03162	alpha-ribazole phosphatase
+UHCUDC	TIGR03164	OHCU decarboxylase
+F1F0_chp_2	TIGR03165	F1/F0 ATPase, Methanosarcina type, subunit 2
+alt_F1F0_F1_eps	TIGR03166	alternate F1F0 ATPase, F1 subunit epsilon
+tRNA_sel_U_synt	TIGR03167	tRNA 2-selenouridine synthase
+1-PFK	TIGR03168	hexose kinase, 1-phosphofructokinase family
+Nterm_to_SelD	TIGR03169	pyridine nucleotide-disulfide oxidoreductase family protein
+flgA_cterm	TIGR03170	flagella basal body P-ring formation protein FlgA
+soxL2	TIGR03171	Rieske iron-sulfur protein SoxL2
+TIGR03172	TIGR03172	putative selenium-dependent hydroxylase accessory protein YqeC
+pbuX	TIGR03173	xanthine permease
+cas_Csc3	TIGR03174	CRISPR type I-D/CYANO-associated protein Csc3/Cas10d
+AllD	TIGR03175	ureidoglycolate dehydrogenase
+AllC	TIGR03176	allantoate amidohydrolase
+pilus_cpaB	TIGR03177	Flp pilus assembly protein CpaB
+allantoinase	TIGR03178	allantoinase
+UraD_2	TIGR03180	OHCU decarboxylase
+PDH_E1_alph_x	TIGR03181	pyruvate dehydrogenase (acetyl-transferring) E1 component, alpha subunit
+PDH_E1_alph_y	TIGR03182	pyruvate dehydrogenase (acetyl-transferring) E1 component, alpha subunit
+DNA_S_dndC	TIGR03183	putative sulfurtransferase DndC
+DNA_S_dndE	TIGR03184	DNA sulfur modification protein DndE
+DNA_S_dndD	TIGR03185	DNA sulfur modification protein DndD
+AKGDH_not_PDH	TIGR03186	alpha-ketoglutarate dehydrogenase
+DGQHR	TIGR03187	DGQHR domain
+histidine_hisI	TIGR03188	phosphoribosyl-ATP diphosphatase
+dienoyl_CoA_hyt	TIGR03189	cyclohexa-1,5-dienecarbonyl-CoA hydratase
+benz_CoA_bzdN	TIGR03190	benzoyl-CoA reductase, bzd-type, N subunit
+benz_CoA_bzdO	TIGR03191	benzoyl-CoA reductase, bzd-type, O subunit
+benz_CoA_bzdQ	TIGR03192	benzoyl-CoA reductase, bzd-type, Q subunit
+4hydroxCoAred	TIGR03193	4-hydroxybenzoyl-CoA reductase, gamma subunit
+4hydrxCoA_A	TIGR03194	4-hydroxybenzoyl-CoA reductase, alpha subunit
+4hydrxCoA_B	TIGR03195	4-hydroxybenzoyl-CoA reductase, beta subunit
+pucD	TIGR03196	xanthine dehydrogenase D subunit
+MnmC_Cterm	TIGR03197	tRNA U-34 5-methylaminomethyl-2-thiouridine biosynthesis protein MnmC, C-terminal domain
+pucE	TIGR03198	xanthine dehydrogenase E subunit
+pucC	TIGR03199	xanthine dehydrogenase C subunit
+dearomat_oah	TIGR03200	6-oxocyclohex-1-ene-1-carbonyl-CoA hydrolase
+dearomat_had	TIGR03201	6-hydroxycyclohex-1-ene-1-carbonyl-CoA dehydrogenase
+pucB	TIGR03202	xanthine dehydrogenase accessory protein pucB
+pimD_small	TIGR03203	pimeloyl-CoA dehydrogenase, small subunit
+pimC_large	TIGR03204	pimeloyl-CoA dehydrogenase, large subunit
+pimA	TIGR03205	dicarboxylate--CoA ligase PimA
+benzo_BadH	TIGR03206	2-hydroxycyclohexanecarboxyl-CoA dehydrogenase
+cyc_hxne_CoA_dh	TIGR03207	cyclohexanecarboxyl-CoA dehydrogenase
+cyc_hxne_CoA_lg	TIGR03208	cyclohexanecarboxylate-CoA ligase
+P21_Cbot	TIGR03209	transcriptional regulator BotR, P-21
+badI	TIGR03210	2-ketocyclohexanecarboxyl-CoA hydrolase
+catechol_2_3	TIGR03211	catechol 2,3 dioxygenase
+uraD_N-term-dom	TIGR03212	putative urate catabolism protein
+23dbph12diox	TIGR03213	2,3-dihydroxybiphenyl 1,2-dioxygenase
+ura-cupin	TIGR03214	putative allantoin catabolism protein
+ac_ald_DH_ac	TIGR03215	acetaldehyde dehydrogenase (acetylating)
+OH_muco_semi_DH	TIGR03216	2-hydroxymuconic semialdehyde dehydrogenase
+4OH_2_O_val_ald	TIGR03217	4-hydroxy-2-oxovalerate aldolase
+catechol_dmpH	TIGR03218	4-oxalocrotonate decarboxylase
+salicylate_mono	TIGR03219	salicylate 1-monooxygenase
+catechol_dmpE	TIGR03220	2-oxopent-4-enoate hydratase
+muco_delta	TIGR03221	muconolactone delta-isomerase
+benzo_boxC	TIGR03222	benzoyl-CoA-dihydrodiol lyase
+Phn_opern_protn	TIGR03223	putative phosphonate metabolism protein
+benzo_boxA	TIGR03224	benzoyl-CoA oxygenase/reductase, BoxA protein
+benzo_boxB	TIGR03225	benzoyl-CoA oxygenase, B subunit
+PhnU	TIGR03226	2-aminoethylphosphonate ABC transporter, permease protein
+PhnS	TIGR03227	2-aminoethylphosphonate ABC transporter, 2-aminoethylphosphonate binding protein
+anthran_1_2_A	TIGR03228	anthranilate 1,2-dioxygenase, large subunit
+benzo_1_2_benA	TIGR03229	benzoate 1,2-dioxygenase, large subunit
+lipo_lipase	TIGR03230	lipoprotein lipase
+anthran_1_2_B	TIGR03231	anthranilate 1,2-dioxygenase, small subunit
+benzo_1_2_benB	TIGR03232	benzoate 1,2-dioxygenase, small subunit
+DNA_S_dndB	TIGR03233	DNA sulfur modification protein DndB
+OH-pyruv-isom	TIGR03234	hydroxypyruvate isomerase
+DNA_S_dndA	TIGR03235	cysteine desulfurase DndA
+dnd_assoc_1	TIGR03236	DNA phosphorothioation-dependent restriction protein DptG
+dnd_assoc_2	TIGR03237	DNA phosphorothioation-dependent restriction protein DptH
+dnd_assoc_3	TIGR03238	DNA phosphorothioation-dependent restriction protein DptF
+GarL	TIGR03239	2-dehydro-3-deoxyglucarate aldolase
+arg_catab_astD	TIGR03240	succinylglutamate-semialdehyde dehydrogenase
+arg_catab_astB	TIGR03241	succinylarginine dihydrolase
+arg_catab_astE	TIGR03242	succinylglutamate desuccinylase
+arg_catab_AOST	TIGR03243	arginine and ornithine succinyltransferase subunits
+arg_catab_AstA	TIGR03244	arginine N-succinyltransferase
+arg_AOST_alph	TIGR03245	arginine/ornithine succinyltransferase, alpha subunit
+arg_catab_astC	TIGR03246	succinylornithine transaminase family
+glucar-dehydr	TIGR03247	glucarate dehydratase
+galactar-dH20	TIGR03248	galactarate dehydratase
+KdgD	TIGR03249	5-dehydro-4-deoxyglucarate dehydratase
+PhnAcAld_DH	TIGR03250	putative phosphonoacetaldehyde dehydrogenase
+LAT_fam	TIGR03251	L-lysine 6-transaminase
+TIGR03252	TIGR03252	uncharacterized HhH-GPD family protein
+oxalate_frc	TIGR03253	formyl-CoA transferase
+oxalate_oxc	TIGR03254	oxalyl-CoA decarboxylase
+PhnV	TIGR03255	2-aminoethylphosphonate ABC transport system, membrane component PhnV
+met_CoM_red_alp	TIGR03256	methyl-coenzyme M reductase, alpha subunit
+met_CoM_red_bet	TIGR03257	methyl-coenzyme M reductase, beta subunit
+PhnT	TIGR03258	2-aminoethylphosphonate ABC transport system, ATP-binding component PhnT
+met_CoM_red_gam	TIGR03259	methyl-coenzyme M reductase, gamma subunit
+met_CoM_red_D	TIGR03260	methyl-coenzyme M reductase operon protein D
+phnS2	TIGR03261	putative 2-aminoethylphosphonate ABC transporter, periplasmic 2-aminoethylphosphonate-binding protein
+PhnU2	TIGR03262	putative 2-aminoethylphosphonate ABC transporter, permease protein
+guanyl_kin	TIGR03263	guanylate kinase
+met_CoM_red_C	TIGR03264	methyl-coenzyme M reductase I operon protein C
+PhnT2	TIGR03265	putative 2-aminoethylphosphonate ABC transporter, ATP-binding protein
+methan_mark_1	TIGR03266	putative methanogenesis marker protein 1
+methan_mark_2	TIGR03267	putative methanogenesis marker protein 2
+methan_mark_3	TIGR03268	putative methanogenesis marker protein 3
+met_CoM_red_A2	TIGR03269	methyl coenzyme M reductase system, component A2
+methan_mark_4	TIGR03270	putative methanogen marker protein 4
+methan_mark_5	TIGR03271	putative methanogenesis marker protein 5
+methan_mark_6	TIGR03272	putative methanogenesis marker protein 6
+methan_mark_7	TIGR03274	putative methanogenesis marker protein 7
+methan_mark_8	TIGR03275	putative methanogenesis marker protein 8
+Phn-HD	TIGR03276	phosphonate degradation operons associated HDIG domain protein
+methan_mark_9	TIGR03277	putative methanogenesis marker domain 9
+methan_mark_10	TIGR03278	methanogenesis marker radical SAM protein
+cyano_FeS_chp	TIGR03279	putative radical SAM enzyme, TIGR03279 family
+methan_mark_11	TIGR03280	methanogenesis imperfect marker protein 11
+methan_mark_12	TIGR03281	putative methanogenesis marker protein 12
+methan_mark_13	TIGR03282	putative methanogenesis marker 13 metalloprotein
+thy_syn_methano	TIGR03283	thymidylate synthase, methanogen type
+thym_sym	TIGR03284	thymidylate synthase
+methan_mark_14	TIGR03285	putative methanogenesis marker protein 14
+methan_mark_15	TIGR03286	putative methanogenesis marker protein 15
+methan_mark_16	TIGR03287	putative methanogenesis marker 16 metalloprotein
+CoB_CoM_SS_B	TIGR03288	CoB--CoM heterodisulfide reductase, subunit B
+frhB	TIGR03289	coenzyme F420 hydrogenase, subunit beta
+CoB_CoM_SS_C	TIGR03290	CoB--CoM heterodisulfide reductase, subunit C
+methan_mark_17	TIGR03291	putative methanogenesis marker protein 17
+PhnH_redo	TIGR03292	phosphonate C-P lyase system protein PhnH
+PhnG_redo	TIGR03293	phosphonate C-P lyase system protein PhnG
+FrhG	TIGR03294	coenzyme F420 hydrogenase, subunit gamma
+frhA	TIGR03295	coenzyme F420 hydrogenase, subunit alpha
+M6dom_TIGR03296	TIGR03296	M6 family metalloprotease domain
+Ppyr-DeCO2ase	TIGR03297	phosphonopyruvate decarboxylase
+argP	TIGR03298	transcriptional regulator, ArgP family
+LGT_TIGR03299	TIGR03299	phage/plasmid-like protein TIGR03299
+assembly_YfgL	TIGR03300	outer membrane assembly lipoprotein YfgL
+PhnW-AepZ	TIGR03301	2-aminoethylphosphonate aminotransferase
+OM_YfiO	TIGR03302	outer membrane assembly lipoprotein YfiO
+OM_YaeT	TIGR03303	outer membrane protein assembly complex, YaeT protein
+OMP85_target	TIGR03304	outer membrane insertion C-terminal signal
+alt_F1F0_F1_bet	TIGR03305	alternate F1F0 ATPase, F1 subunit beta
+altF1_A	TIGR03306	alternate F1F0 ATPase, F0 subunit A
+PhnP	TIGR03307	phosphonate metabolism protein PhnP
+phn_thr-fam	TIGR03308	phosphonate metabolim protein, transferase hexapeptide repeat family
+matur_yqeB	TIGR03309	selenium-dependent molybdenum hydroxylase system protein, YqeB family
+matur_MocA_YgfJ	TIGR03310	molybdenum cofactor cytidylyltransferase
+Se_dep_XDH	TIGR03311	selenium-dependent xanthine dehydrogenase
+Se_sel_red_FAD	TIGR03312	probable selenate reductase, FAD-binding subunit
+Se_sel_red_Mo	TIGR03313	probable selenate reductase, molybdenum-binding subunit
+Se_ssnA	TIGR03314	putative selenium metabolism protein SsnA
+Se_ygfK	TIGR03315	putative selenate reductase, YgfK subunit
+ygeW	TIGR03316	knotted carbamoyltransferase YgeW
+ygfZ_signature	TIGR03317	folate-binding protein YgfZ
+YdfZ_fam	TIGR03318	putative selenium-binding protein YdfZ
+RNase_Y	TIGR03319	ribonuclease Y
+alt_F1F0_F0_B	TIGR03321	alternate F1F0 ATPase, F0 subunit B
+alt_F1F0_F0_C	TIGR03322	alternate F1F0 ATPase, F0 subunit C
+alt_F1F0_F1_gam	TIGR03323	alternate F1F0 ATPase, F1 subunit gamma
+alt_F1F0_F1_al	TIGR03324	alternate F1F0 ATPase, F1 subunit alpha
+BphB_TodD	TIGR03325	cis-2,3-dihydrobiphenyl-2,3-diol dehydrogenase
+rubisco_III	TIGR03326	ribulose bisphosphate carboxylase, type III
+AMP_phos	TIGR03327	AMP phosphorylase
+salvage_mtnB	TIGR03328	methylthioribulose-1-phosphate dehydratase
+Phn_aa_oxid	TIGR03329	putative aminophosphonate oxidoreductase
+SAM_DCase_Bsu	TIGR03330	S-adenosylmethionine decarboxylase proenzyme
+SAM_DCase_Eco	TIGR03331	S-adenosylmethionine decarboxylase proenzyme
+salvage_mtnW	TIGR03332	2,3-diketo-5-methylthiopentyl-1-phosphate enolase
+salvage_mtnX	TIGR03333	2-hydroxy-3-keto-5-methylthiopentenyl-1-phosphate phosphatase
+IOR_beta	TIGR03334	indolepyruvate ferredoxin oxidoreductase, beta subunit
+F390_ftsA	TIGR03335	coenzyme F390 synthetase
+IOR_alpha	TIGR03336	indolepyruvate ferredoxin oxidoreductase, alpha subunit
+phnR	TIGR03337	phosphonate utilization transcriptional regulator PhnR
+phnR_burk	TIGR03338	phosphonate utilization associated transcriptional regulator
+phn_lysR	TIGR03339	aminoethylphosphonate catabolism associated LysR family transcriptional regulator
+phn_DUF6	TIGR03340	phosphonate utilization associated putative membrane protein
+YhgI_GntY	TIGR03341	IscR-regulated protein YhgI
+dsrC_tusE_dsvC	TIGR03342	sulfur relay protein, TusE/DsrC/DsvC family
+biphenyl_bphD	TIGR03343	2-hydroxy-6-oxo-6-phenylhexa-2,4-dienoate hydrolase
+VI_effect_Hcp1	TIGR03344	type VI secretion system effector, Hcp1 family
+VI_ClpV1	TIGR03345	type VI secretion ATPase, ClpV1 family
+chaperone_ClpB	TIGR03346	ATP-dependent chaperone protein ClpB
+VI_chp_1	TIGR03347	type VI secretion protein, VC_A0111 family
+VI_IcmF	TIGR03348	type VI secretion protein IcmF
+IV_VI_DotU	TIGR03349	type IV/VI secretion system protein, DotU family
+type_VI_ompA	TIGR03350	type VI secretion system peptidoglycan-associated domain
+PhnX-like	TIGR03351	phosphonatase-like hydrolase
+VI_chp_3	TIGR03352	type VI secretion lipoprotein, VC_A0113 family
+VI_chp_4	TIGR03353	type VI secretion protein, VC_A0114 family
+VI_FHA	TIGR03354	type VI secretion system FHA domain protein
+VI_chp_2	TIGR03355	type VI secretion protein, EvpB/VC_A0108 family
+BGL	TIGR03356	beta-galactosidase
+VI_zyme	TIGR03357	type VI secretion system lysozyme-like protein
+VI_chp_5	TIGR03358	type VI secretion protein, VC_A0107 family
+VI_chp_6	TIGR03359	type VI secretion protein, TIGR03359 family
+VI_minor_1	TIGR03360	type VI secretion-associated protein, VC_A0118 family
+VI_Rhs_Vgr	TIGR03361	type VI secretion system Vgr family protein
+VI_chp_7	TIGR03362	type VI secretion-associated protein, VC_A0119 family
+VI_chp_8	TIGR03363	type VI secretion-associated protein, ImpA family
+HpnW_proposed	TIGR03364	FAD dependent oxidoreductase TIGR03364
+Bsubt_queE	TIGR03365	7-cyano-7-deazaguanosine (preQ0) biosynthesis protein QueE
+HpnZ_proposed	TIGR03366	putative phosphonate catabolism associated alcohol dehydrogenase
+queuosine_QueD	TIGR03367	queuosine biosynthesis protein QueD
+cellulose_yhjU	TIGR03368	cellulose synthase operon protein YhjU
+cellulose_bcsE	TIGR03369	cellulose biosynthesis protein BcsE
+VPLPA-CTERM	TIGR03370	VPLPA-CTERM protein sorting domain
+cellulose_yhjQ	TIGR03371	cellulose synthase operon protein YhjQ
+putres_am_tran	TIGR03372	putrescine aminotransferase
+VI_minor_4	TIGR03373	type VI secretion-associated protein, BMA_A0400 family
+ABALDH	TIGR03374	1-pyrroline dehydrogenase
+type_I_sec_LssB	TIGR03375	type I secretion system ATPase
+glycerol3P_DH	TIGR03376	glycerol-3-phosphate dehydrogenase (NAD(+))
+glycerol3P_GlpA	TIGR03377	glycerol-3-phosphate dehydrogenase, anaerobic, A subunit
+glycerol3P_GlpB	TIGR03378	glycerol-3-phosphate dehydrogenase, anaerobic, B subunit
+glycerol3P_GlpC	TIGR03379	glycerol-3-phosphate dehydrogenase, anaerobic, C subunit
+agmatine_aguA	TIGR03380	agmatine deiminase
+agmatine_aguB	TIGR03381	N-carbamoylputrescine amidase
+GC_trans_RRR	TIGR03382	Myxococcales GC_trans_RRR domain
+urate_oxi	TIGR03383	urate oxidase
+betaine_BetI	TIGR03384	transcriptional repressor BetI
+CoA_CoA_reduc	TIGR03385	CoA-disulfide reductase
+ascorbase	TIGR03388	L-ascorbate oxidase
+laccase	TIGR03389	laccase
+ascorbOXfungal	TIGR03390	L-ascorbate oxidase
+FeS_syn_CsdE	TIGR03391	cysteine desulfurase, sulfur acceptor subunit CsdE
+FeS_syn_CsdA	TIGR03392	cysteine desulfurase, catalytic subunit CsdA
+indolpyr_decarb	TIGR03393	indolepyruvate decarboxylase
+indol_phenyl_DC	TIGR03394	indolepyruvate/phenylpyruvate decarboxylase
+sphingomy	TIGR03395	sphingomyelin phosphodiesterase
+PC_PLC	TIGR03396	phospholipase C, phosphocholine-specific
+acid_phos_Burk	TIGR03397	acid phosphatase, Burkholderia-type
+plc_access_R	TIGR03398	phospholipase C accessory protein PlcR
+RNA_3prim_cycl	TIGR03399	RNA 3'-phosphate cyclase
+18S_RNA_Rcl1p	TIGR03400	18S rRNA biogenesis protein RCL1
+cyanamide_fam	TIGR03401	HD domain protein, cyanamide hydratase family
+FeS_nifS	TIGR03402	cysteine desulfurase NifS
+nifS_epsilon	TIGR03403	cysteine desulfurase, NifS family
+bicupin_oxalic	TIGR03404	bicupin, oxalate decarboxylase family
+Phn_Fe-ADH	TIGR03405	phosphonate metabolism-associated iron-containing alcohol dehydrogenase
+FeS_long_SufT	TIGR03406	probable FeS assembly SUF system protein SufT
+urea_ABC_UrtA	TIGR03407	urea ABC transporter, urea binding protein
+urea_trans_UrtC	TIGR03408	urea ABC transporter, permease protein UrtC
+urea_trans_UrtB	TIGR03409	urea ABC transporter, permease protein UrtB
+urea_trans_UrtE	TIGR03410	urea ABC transporter, ATP-binding protein UrtE
+urea_trans_UrtD	TIGR03411	urea ABC transporter, ATP-binding protein UrtD
+iscX_yfhJ	TIGR03412	FeS assembly protein IscX
+GSH_gloB	TIGR03413	hydroxyacylglutathione hydrolase
+ABC_choline_bnd	TIGR03414	choline ABC transporter, periplasmic binding protein
+ABC_choXWV_ATP	TIGR03415	choline ABC transporter, ATP-binding protein
+ABC_choXWV_perm	TIGR03416	choline ABC transporter, permease protein
+chol_sulfatase	TIGR03417	choline-sulfatase
+chol_sulf_TF	TIGR03418	putative choline sulfate-utilization transcription factor
+NifU_clost	TIGR03419	FeS cluster assembly scaffold protein NifU
+DnaA_homol_Hda	TIGR03420	DnaA regulatory inactivator Hda
+FeS_CyaY	TIGR03421	iron donor protein CyaY
+mito_frataxin	TIGR03422	frataxin
+pbp2_mrdA	TIGR03423	penicillin-binding protein 2
+urea_degr_1	TIGR03424	urea carboxylase-associated protein 1
+urea_degr_2	TIGR03425	urea carboxylase-associated protein 2
+shape_MreD	TIGR03426	rod shape-determining protein MreD
+ABC_peri_uca	TIGR03427	ABC transporter periplasmic binding protein, urea carboxylase region
+ureacarb_perm	TIGR03428	permease, urea carboxylase system
+arom_pren_DMATS	TIGR03429	aromatic prenyltransferase, DMATS type
+trp_dimet_allyl	TIGR03430	tryptophan dimethylallyltransferase
+PhnD	TIGR03431	phosphonate ABC transporter, periplasmic phosphonate binding protein
+yjhG_yagF	TIGR03432	putative dehydratase, YjhG/YagF family
+padR_acidobact	TIGR03433	transcriptional regulator, Acidobacterial, PadR-family
+ADOP	TIGR03434	acidobacterial duplicated orphan permease
+Soli_TIGR03435	TIGR03435	soil-associated protein, TIGR03435 family
+acidobact_VWFA	TIGR03436	VWFA-related Acidobacterial domain
+Soli_cterm	TIGR03437	Solibacter uncharacterized C-terminal domain
+egtD_ergothio	TIGR03438	dimethylhistidine N-methyltransferase
+methyl_EasF	TIGR03439	probable methyltransferase domain, EasF family
+egtB_TIGR03440	TIGR03440	ergothioneine biosynthesis protein EgtB
+urea_trans_yut	TIGR03441	urea transporter
+TIGR03442	TIGR03442	ergothioneine biosynthesis protein EgtC
+alpha_am_amid	TIGR03443	L-aminoadipate-semialdehyde dehydrogenase
+EgtA_Cys_ligase	TIGR03444	ergothioneine biosynthesis glutamate--cysteine ligase EgtA
+mycothiol_MshB	TIGR03445	N-acetyl-1-D-myo-inositol-2-amino-2-deoxy-alpha-D-glucopyranoside deacetylase
+mycothiol_Mca	TIGR03446	mycothiol conjugate amidase Mca
+mycothiol_MshC	TIGR03447	cysteine--1-D-myo-inosityl 2-amino-2-deoxy-alpha-D-glucopyranoside ligase
+mycothiol_MshD	TIGR03448	mycothiol synthase
+mycothiol_MshA	TIGR03449	D-inositol-3-phosphate glycosyltransferase
+mycothiol_INO1	TIGR03450	inositol 1-phosphate synthase
+mycoS_dep_FDH	TIGR03451	S-(hydroxymethyl)mycothiol dehydrogenase
+mycothione_red	TIGR03452	mycothione reductase
+partition_RepA	TIGR03453	plasmid partitioning protein RepA
+partition_RepB	TIGR03454	plasmid partitioning protein RepB
+HisG_C-term	TIGR03455	ATP phosphoribosyltransferase, C-terminal domain
+sulphoacet_xsc	TIGR03457	sulfoacetaldehyde acetyltransferase
+YgfH_subfam	TIGR03458	succinate CoA transferase
+crt_membr	TIGR03459	carotene biosynthesis associated membrane protein
+crt_membr_arch	TIGR03460	carotene biosynthesis associated membrane protein
+pabC_Proteo	TIGR03461	aminodeoxychorismate lyase
+CarR_dom_SF	TIGR03462	lycopene cyclase domain
+osq_cycl	TIGR03463	2,3-oxidosqualene cyclase
+HpnC	TIGR03464	squalene synthase HpnC
+HpnD	TIGR03465	squalene synthase HpnD
+HpnA	TIGR03466	hopanoid-associated sugar epimerase
+HpnE	TIGR03467	squalene-associated FAD-dependent desaturase
+HpnG	TIGR03468	hopanoid-associated phosphorylase
+HpnB	TIGR03469	hopene-associated glycosyltransferase HpnB
+HpnH	TIGR03470	hopanoid biosynthesis associated radical SAM protein HpnH
+HpnJ	TIGR03471	hopanoid biosynthesis associated radical SAM protein HpnJ
+HpnI	TIGR03472	hopanoid biosynthesis associated glycosyl transferase protein HpnI
+HpnK	TIGR03473	hopanoid biosynthesis associated protein HpnK
+incFII_RepA	TIGR03474	incFII family plasmid replication initiator RepA
+tap_IncFII_lead	TIGR03475	RepA leader peptide Tap
+HpnL	TIGR03476	putative membrane protein
+DMSO_red_II_gam	TIGR03477	DMSO reductase family type II enzyme, heme b subunit
+DMSO_red_II_bet	TIGR03478	DMSO reductase family type II enzyme, iron-sulfur subunit
+DMSO_red_II_alp	TIGR03479	DMSO reductase family type II enzyme, molybdopterin subunit
+HpnN	TIGR03480	hopanoid biosynthesis associated RND transporter like protein HpnN
+HpnM	TIGR03481	hopanoid biosynthesis associated membrane protein HpnM
+DMSO_red_II_cha	TIGR03482	DMSO reductase family type II enzyme chaperone
+FtsZ_alphas_C	TIGR03483	cell division protein FtsZ, alphaProteobacterial C-terminal extension
+cas_csx13_N	TIGR03485	CRISPR-associated protein Cas8a1/Csx13, MYXAN subtype
+cas_csx13_C	TIGR03486	CRISPR-associated protein Cas8a1/Csx13, MYXAN subtype, C-terminal region
+cas_csp2	TIGR03487	CRISPR-associated protein Cas8c/Csp2, subtype PGING
+cas_Cas5p	TIGR03488	CRISPR-associated protein Cas5, subtype PGING
+cas_csp1	TIGR03489	CRISPR-associated protein Cas7/Csp1, subtype PGING
+Mycoplas_LppA	TIGR03490	mycoides cluster lipoprotein, LppA/P72 family
+TIGR03491	TIGR03491	putative RecB family nuclease, TM0106 family
+TIGR03492	TIGR03492	conserved hypothetical protein
+cellullose_BcsF	TIGR03493	celllulose biosynthesis operon protein BcsF/YhjT
+salicyl_syn	TIGR03494	salicylate synthase
+phage_LysB	TIGR03495	phage lysis regulatory protein, LysB family
+FliI_clade1	TIGR03496	flagellar protein export ATPase FliI
+FliI_clade2	TIGR03497	flagellar protein export ATPase FliI
+FliI_clade3	TIGR03498	flagellar protein export ATPase FliI
+FlhF	TIGR03499	flagellar biosynthesis protein FlhF
+FliO_TIGR	TIGR03500	flagellar biosynthetic protein FliO
+GlyGly_CTERM	TIGR03501	GlyGly-CTERM domain
+lipase_Pla1_cef	TIGR03502	extracellular lipase, Pla-1/cef family
+TIGR03503	TIGR03503	TIGR03503 family protein
+FimV_Cterm	TIGR03504	FimV C-terminal domain
+FimV_core	TIGR03505	FimV N-terminal domain
+FlgEFG_subfam	TIGR03506	flagellar hook-basal body protein
+decahem_SO1788	TIGR03507	decaheme c-type cytochrome, OmcA/MtrC family
+decahem_SO	TIGR03508	decaheme c-type cytochrome, DmsE family
+OMP_MtrB_PioB	TIGR03509	decaheme-associated outer membrane protein, MtrB/PioB family
+XapX	TIGR03510	XapX domain
+GldH_lipo	TIGR03511	gliding motility-associated lipoprotein GldH
+GldD_lipo	TIGR03512	gliding motility-associated lipoprotein GldD
+GldL_gliding	TIGR03513	gliding motility-associated protein GldL
+GldB_lipo	TIGR03514	gliding motility-associated lipoprotein GldB
+GldC	TIGR03515	gliding motility-associated protein GldC
+ppisom_GldI	TIGR03516	peptidyl-prolyl isomerase, gliding motility-associated
+GldM_gliding	TIGR03517	gliding motility-associated protein GldM
+ABC_perm_GldF	TIGR03518	gliding motility-associated ABC transporter permease protein GldF
+T9SS_PorP_fam	TIGR03519	type IX secretion system membrane protein, PorP/SprF family
+GldE	TIGR03520	gliding motility-associated protein GldE
+GldG	TIGR03521	gliding-associated putative ABC transporter substrate-binding component GldG
+GldA_ABC_ATP	TIGR03522	gliding motility-associated ABC transporter ATP-binding subunit GldA
+GldN	TIGR03523	gliding motility associated protein GldN
+GldJ	TIGR03524	gliding motility-associated lipoprotein GldJ
+GldK	TIGR03525	gliding motility-associated lipoprotein GldK
+selenium_YgeY	TIGR03526	putative selenium metabolism hydrolase
+selenium_YedF	TIGR03527	selenium metabolism protein YedF
+2_3_DAP_am_ly	TIGR03528	diaminopropionate ammonia-lyase
+GldK_short	TIGR03529	gliding motility-associated lipoprotein GldK
+GldJ_short	TIGR03530	gliding motility-associated lipoprotein GldJ
+selenium_SpcS	TIGR03531	O-phosphoseryl-tRNA(Sec) selenium transferase
+DapD_Ac	TIGR03532	2,3,4,5-tetrahydropyridine-2,6-dicarboxylate N-acetyltransferase
+L3_gln_methyl	TIGR03533	protein-(glutamine-N5) methyltransferase, ribosomal protein L3-specific
+RF_mod_PrmC	TIGR03534	protein-(glutamine-N5) methyltransferase, release factor-specific
+DapD_actino	TIGR03535	2,3,4,5-tetrahydropyridine-2,6-dicarboxylate N-succinyltransferase
+DapD_gpp	TIGR03536	2,3,4,5-tetrahydropyridine-2,6-dicarboxylate N-succinyltransferase
+DapC	TIGR03537	succinyldiaminopimelate transaminase
+DapC_gpp	TIGR03538	succinyldiaminopimelate transaminase
+DapC_actino	TIGR03539	succinyldiaminopimelate transaminase
+DapC_direct	TIGR03540	LL-diaminopimelate aminotransferase
+reg_near_HchA	TIGR03541	LuxR family transcriptional regulatory, chaperone HchA-associated
+DAPAT_plant	TIGR03542	LL-diaminopimelate aminotransferase
+divI1A_rptt_fam	TIGR03543	DivIVA domain repeat protein
+DivI1A_domain	TIGR03544	DivIVA domain
+TIGR03545	TIGR03545	TIGR03545 family protein
+TIGR03546	TIGR03546	TIGR03546 family protein
+muta_rot_YjhT	TIGR03547	mutatrotase, YjhT family
+mutarot_permut	TIGR03548	cyclically-permuted mutarotase family protein
+TIGR03549	TIGR03549	YcaO domain protein
+F420_cofG	TIGR03550	7,8-didemethyl-8-hydroxy-5-deazariboflavin synthase, CofG subunit
+F420_cofH	TIGR03551	7,8-didemethyl-8-hydroxy-5-deazariboflavin synthase, CofH subunit
+F420_cofC	TIGR03552	2-phospho-L-lactate guanylyltransferase
+F420_FbiB_CTERM	TIGR03553	F420 biosynthesis protein FbiB, C-terminal domain
+F420_G6P_DH	TIGR03554	glucose-6-phosphate dehydrogenase (coenzyme-F420)
+F420_mer	TIGR03555	5,10-methylenetetrahydromethanopterin reductase
+photolyase_8HDF	TIGR03556	deoxyribodipyrimidine photo-lyase, 8-HDF type
+F420_G6P_family	TIGR03557	F420-dependent oxidoreductase, G6PDH family
+oxido_grp_1	TIGR03558	luciferase family oxidoreductase, group 1
+F420_Rv3520c	TIGR03559	probable F420-dependent oxidoreductase, Rv3520c family
+F420_Rv1855c	TIGR03560	probable F420-dependent oxidoreductase, Rv1855c family
+organ_hyd_perox	TIGR03561	peroxiredoxin, Ohr subfamily
+osmo_induc_OsmC	TIGR03562	peroxiredoxin, OsmC subfamily
+perox_SACOL1771	TIGR03563	peroxiredoxin, SACOL1771 subfamily
+F420_MSMEG_4879	TIGR03564	F420-dependent oxidoreductase, MSMEG_4879 family
+alk_sulf_monoox	TIGR03565	alkanesulfonate monooxygenase, FMNH(2)-dependent
+FMN_reduc_MsuE	TIGR03566	FMN reductase
+FMN_reduc_SsuE	TIGR03567	FMN reductase
+NeuC_NnaA	TIGR03568	UDP-N-acetyl-D-glucosamine 2-epimerase, UDP-hydrolysing
+NeuB_NnaB	TIGR03569	N-acetylneuraminate synthase
+NeuD_NnaD	TIGR03570	sugar O-acyltransferase, sialic acid O-acetyltransferase NeuD family
+lucif_BA3436	TIGR03571	luciferase-type oxidoreductase, BA3436 family
+WbuZ	TIGR03572	glycosyl amidation-associated protein WbuZ
+WbuX	TIGR03573	N-acetyl sugar amidotransferase
+selen_PSTK	TIGR03574	L-seryl-tRNA(Sec) kinase
+selen_PSTK_euk	TIGR03575	L-seryl-tRNA(Sec) kinase
+pyridox_MJ0158	TIGR03576	pyridoxal phosphate enzyme, MJ0158 family
+EF_0830	TIGR03577	conserved hypothetical protein EF_0830/AHA_3911
+EF_0831	TIGR03578	conserved hypothetical protein EF_0831/AHA_3912
+EF_0833	TIGR03579	conserved hypothetical protein EF_0833/AHA_3914
+EF_0832	TIGR03580	conserved hypothetical protein EF_0832/AHA_3913
+EF_0839	TIGR03581	conserved hypothetical protein EF_0839/AHA_3917
+EF_0829	TIGR03582	PRD domain protein, EF_0829/AHA_3910 family
+EF_0837	TIGR03583	putative amidohydrolase, EF_0837/AHA_3915 family
+PseF	TIGR03584	pseudaminic acid cytidylyltransferase
+PseH	TIGR03585	UDP-4-amino-4,6-dideoxy-N-acetyl-beta-L-altrosamine N-acetyltransferase
+PseI	TIGR03586	pseudaminic acid synthase
+Pse_Me-ase	TIGR03587	pseudaminic acid biosynthesis-associated methylase
+PseC	TIGR03588	UDP-4-amino-4,6-dideoxy-N-acetyl-beta-L-altrosamine transaminase
+PseB	TIGR03589	UDP-N-acetylglucosamine 4,6-dehydratase (inverting)
+PseG	TIGR03590	UDP-2,4-diacetamido-2,4,6-trideoxy-beta-L-altropyranose hydrolase
+polynuc_phos	TIGR03591	polyribonucleotide nucleotidyltransferase
+yidC_oxa1_cterm	TIGR03592	membrane protein insertase, YidC/Oxa1 family
+yidC_nterm	TIGR03593	membrane protein insertase, YidC/Oxa1 family, N-terminal domain
+GTPase_EngA	TIGR03594	ribosome-associated GTPase EngA
+Obg_CgtA_exten	TIGR03595	Obg family GTPase CgtA, C-terminal extension
+GTPase_YlqF	TIGR03596	ribosome biogenesis GTP-binding protein YlqF
+GTPase_YqeH	TIGR03597	ribosome biogenesis GTPase YqeH
+GTPase_YsxC	TIGR03598	ribosome biogenesis GTP-binding protein YsxC
+YloV	TIGR03599	DAK2 domain fusion protein YloV
+phage_DnaB	TIGR03600	phage replicative helicase, DnaB family
+B_an_ocin	TIGR03601	bacteriocin, heterocycloanthracin/sonorensin family
+streptolysinS	TIGR03602	bacteriocin protoxin, streptolysin S family
+cyclo_dehy_ocin	TIGR03603	thiazole/oxazole-forming peptide maturase, SagC family component
+TOMM_cyclo_SagD	TIGR03604	thiazole/oxazole-forming peptide maturase, SagD family component
+antibiot_sagB	TIGR03605	SagB-type dehydrogenase domain
+non_repeat_PQQ	TIGR03606	dehydrogenase, PQQ-dependent, s-GDH family
+TIGR03607	TIGR03607	patatin-related protein
+L_ocin_972_ABC	TIGR03608	putative bacteriocin export ABC transporter, lactococcin 972 group
+S_layer_CsaB	TIGR03609	polysaccharide pyruvyl transferase CsaB
+RutC	TIGR03610	pyrimidine utilization protein C
+RutD	TIGR03611	pyrimidine utilization protein D
+RutA	TIGR03612	pyrimidine utilization protein A
+RutR	TIGR03613	pyrimidine utilization regulatory protein R
+RutB	TIGR03614	pyrimidine utilization protein B
+RutF	TIGR03615	pyrimidine utilization flavin reductase protein F
+RutG	TIGR03616	pyrimidine utilization transport protein G
+F420_MSMEG_2256	TIGR03617	probable F420-dependent oxidoreductase, MSMEG_2256 family
+Rv1155_F420	TIGR03618	PPOX class probable F420-dependent enzyme
+F420_Rv2161c	TIGR03619	probable F420-dependent oxidoreductase, Rv2161c family
+F420_MSMEG_4141	TIGR03620	probable F420-dependent oxidoreductase, MSMEG_4141 family
+F420_MSMEG_2516	TIGR03621	probable F420-dependent oxidoreductase, MSMEG_2516 family
+urea_t_UrtB_arc	TIGR03622	urea ABC transporter, permease protein UrtB
+TIGR03623	TIGR03623	probable DNA repair protein
+TIGR03624	TIGR03624	putative hydrolase
+L3_bact	TIGR03625	50S ribosomal protein uL3
+L3_arch	TIGR03626	ribosomal protein uL3
+uS9_arch	TIGR03627	ribosomal protein uS9
+arch_S11P	TIGR03628	ribosomal protein uS11
+uS13_arch	TIGR03629	ribosomal protein uS13
+uS17_arch	TIGR03630	ribosomal protein uS17
+uS13_bact	TIGR03631	ribosomal protein uS13
+uS11_bact	TIGR03632	ribosomal protein uS11
+arc_protsome_A	TIGR03633	proteasome endopeptidase complex, archaeal, alpha subunit
+arc_protsome_B	TIGR03634	proteasome endopeptidase complex, archaeal, beta subunit
+uS17_bact	TIGR03635	ribosomal protein uS17
+uL23_arch	TIGR03636	ribosomal protein uL23
+cas1_YPEST	TIGR03637	CRISPR-associated endonuclease Cas1, subtype I-F/YPEST
+cas1_ECOLI	TIGR03638	CRISPR-associated endonuclease Cas1, subtype I-E/ECOLI
+cas1_NMENI	TIGR03639	CRISPR-associated endonuclease Cas1, subtype II/NMENI
+cas1_DVULG	TIGR03640	CRISPR-associated endonuclease Cas1, subtype I-C/DVULG
+cas1_HMARI	TIGR03641	CRISPR-associated endonuclease Cas1, subtype I-B/HMARI/TNEAP
+cas_csx14	TIGR03642	CRISPR-associated protein, Csx14 family
+TIGR03643	TIGR03643	TIGR03643 family protein
+marine_trans_1	TIGR03644	probable ammonium transporter, marine subtype
+glyox_marine	TIGR03645	lactoylglutathione lyase family protein
+YtoQ_fam	TIGR03646	YtoQ family protein
+Na_symport_sm	TIGR03647	putative solute:sodium symporter small subunit
+Na_symport_lg	TIGR03648	probable sodium:solute symporter, VC_2705 subfamily
+ergot_EASG	TIGR03649	ergot alkaloid biosynthesis protein, AFUA_2G17970 family
+violacein_E	TIGR03650	violacein biosynthesis enzyme VioE
+circ_ocin_uber	TIGR03651	circular bacteriocin, circularin A/uberolysin family
+FeS_repair_RIC	TIGR03652	iron-sulfur cluster repair di-iron protein
+uL6_arch	TIGR03653	ribosomal protein uL6
+L6_bact	TIGR03654	ribosomal protein uL6
+anti_R_Lar	TIGR03655	restriction alleviation protein, Lar family
+IsdC	TIGR03656	heme uptake protein IsdC
+IsdB	TIGR03657	heme uptake protein IsdB
+IsdH_HarA	TIGR03658	haptoglobin-binding heme uptake protein HarA
+IsdE	TIGR03659	heme ABC transporter, heme-binding protein isdE
+T1SS_rpt_143	TIGR03660	T1SS-143 repeat domain
+T1SS_VCA0849	TIGR03661	type I secretion C-terminal target domain (VC_A0849 subclass)
+Chlor_Arch_YYY	TIGR03662	chlor_Arch_YYY domain
+TIGR03663	TIGR03663	TIGR03663 family protein
+fut_nucase	TIGR03664	futalosine hydrolase
+arCOG04150	TIGR03665	arCOG04150 universal archaeal KH domain protein
+Rv2061_F420	TIGR03666	PPOX class probable F420-dependent enzyme, Rv2061 family
+Rv3369	TIGR03667	PPOX class probable F420-dependent enzyme, Rv3369 family
+Rv0121_F420	TIGR03668	PPOX class probable F420-dependent enzyme, Rv0121 family
+urea_ABC_arch	TIGR03669	urea ABC transporter, substrate-binding protein
+rpoB_arch	TIGR03670	DNA-directed RNA polymerase subunit B
+cca_archaeal	TIGR03671	CCA-adding enzyme
+rpl4p_arch	TIGR03672	50S ribosomal protein uL4
+uL14_arch	TIGR03673	50S ribosomal protein uL14
+fen_arch	TIGR03674	flap structure-specific endonuclease
+arCOG00543	TIGR03675	arCOG00543 universal archaeal KH-domain/beta-lactamase-domain protein
+aRF1/eRF1	TIGR03676	peptide chain release factor 1, archaeal and eukaryotic forms
+eL8_ribo	TIGR03677	ribosomal protein eL8
+het_cyc_patell	TIGR03678	bacteriocin leader peptide, microcyclamide/patellamide family
+arCOG00187	TIGR03679	arCOG00187 universal archaeal metal-binding-domain/4Fe-4S-binding-domain containing ABC transporter, ATP-binding protein
+eif2g_arch	TIGR03680	translation initiation factor 2, gamma subunit
+arCOG04112	TIGR03682	diphthamide biosynthesis enzyme Dph2
+A-tRNA_syn_arch	TIGR03683	alanine--tRNA ligase
+arCOG00985	TIGR03684	arCOG04150 universal archaeal PUA-domain protein
+ribo_P1_arch	TIGR03685	50S ribosomal protein P1
+pupylate_PafA	TIGR03686	Pup--protein ligase
+pupylate_cterm	TIGR03687	ubiquitin-like protein Pup
+pupylate_PafA2	TIGR03688	proteasome accessory factor PafA2
+pup_AAA	TIGR03689	proteasome ATPase
+20S_bact_beta	TIGR03690	proteasome, beta subunit
+20S_bact_alpha	TIGR03691	proteasome, alpha subunit
+ATP_dep_HslV	TIGR03692	ATP-dependent protease HslVU, peptidase subunit
+ocin_ThiF_like	TIGR03693	putative thiazole-containing bacteriocin maturation protein
+exosort_acyl	TIGR03694	N-acyl amino acid synthase, PEP-CTERM/exosortase system-associated
+menH_SHCHC	TIGR03695	2-succinyl-6-hydroxy-2,4-cyclohexadiene-1-carboxylate synthase
+Rhs_assc_core	TIGR03696	RHS repeat-associated core domain
+NtcA_cyano	TIGR03697	global nitrogen regulator NtcA
+clan_AA_DTGF	TIGR03698	clan AA aspartic protease, AF_0612 family
+menaquin_MqnC	TIGR03699	dehypoxanthine futalosine cyclase
+mena_SCO4494	TIGR03700	putative menaquinone biosynthesis radical SAM enzyme, SCO4494 family
+mena_SCO4490	TIGR03701	menaquinone biosynthesis decarboxylase, SCO4490 family
+lip_kinase_YegS	TIGR03702	lipid kinase YegS
+plsB	TIGR03703	glycerol-3-phosphate O-acyltransferase
+PrmC_rel_meth	TIGR03704	putative protein-(glutamine-N5) methyltransferase, unknown substrate-specific
+poly_P_kin	TIGR03705	polyphosphate kinase 1
+exo_poly_only	TIGR03706	exopolyphosphatase
+PPK2_P_aer	TIGR03707	polyphosphate kinase 2
+poly_P_AMP_trns	TIGR03708	polyphosphate:AMP phosphotransferase
+PPK2_rel_1	TIGR03709	polyphosphate:nucleotide phosphotransferase, PPK2 family
+OAFO_sf	TIGR03710	2-oxoacid:acceptor oxidoreductase, alpha subunit
+acc_sec_asp3	TIGR03711	accessory Sec system protein Asp3
+acc_sec_asp2	TIGR03712	accessory Sec system protein Asp2
+acc_sec_asp1	TIGR03713	accessory Sec system protein Asp1
+secA2	TIGR03714	accessory Sec system translocase SecA2
+KxYKxGKxW	TIGR03715	KxYKxGKxW signal peptide
+R_switched_YkoY	TIGR03716	integral membrane protein, YkoY family
+R_switched_YjbE	TIGR03717	integral membrane protein, YjbE family
+R_switched_Alx	TIGR03718	integral membrane protein, TerC family
+ABC_ABC_ChvD	TIGR03719	ATP-binding cassette protein, ChvD family
+exospor_lead	TIGR03720	exosporium leader peptide
+exospore_TM	TIGR03721	BclB C-terminal domain
+arch_KAE1	TIGR03722	universal archaeal protein Kae1
+T6A_TsaD_YgjD	TIGR03723	tRNA threonylcarbamoyl adenosine modification protein TsaD
+arch_bud32	TIGR03724	Kae1-associated kinase Bud32
+T6A_YeaZ	TIGR03725	tRNA threonylcarbamoyl adenosine modification protein YeaZ
+strep_RK_lipo	TIGR03726	putative cross-wall-targeting lipoprotein signal
+urea_t_UrtC_arc	TIGR03727	urea ABC transporter, permease protein UrtC
+glyco_access_1	TIGR03728	glycosyltransferase, SP_1767 family
+acc_ester	TIGR03729	putative phosphoesterase
+tungstate_WtpA	TIGR03730	tungstate ABC transporter binding protein WtpA
+lantibio_gallid	TIGR03731	lantibiotic, gallidermin/nisin family
+lanti_perm_MutE	TIGR03732	lantibiotic protection ABC transporter permease subunit, MutE/EpiE family
+lanti_perm_MutG	TIGR03733	lantibiotic protection ABC transporter permease subunit, MutG family
+PRTRC_parB	TIGR03734	PRTRC system ParB family protein
+PRTRC_A	TIGR03735	PRTRC system protein A
+PRTRC_ThiF	TIGR03736	PRTRC system ThiF family protein
+PRTRC_B	TIGR03737	PRTRC system protein B
+PRTRC_C	TIGR03738	PRTRC system protein C
+PRTRC_D	TIGR03739	PRTRC system protein D
+galliderm_ABC	TIGR03740	lantibiotic protection ABC transporter, ATP-binding subunit
+PRTRC_E	TIGR03741	PRTRC system protein E
+PRTRC_F	TIGR03742	PRTRC system protein F
+SXT_TraD	TIGR03743	conjugative coupling factor TraD, SXT/TOL subfamily
+traC_PFL_4706	TIGR03744	conjugative transfer ATPase, PFL_4706 family
+conj_TIGR03745	TIGR03745	integrating conjugative element membrane protein, PFL_4702 family
+conj_TIGR03746	TIGR03746	integrating conjugative element protein, PFL_4703 family
+conj_TIGR03747	TIGR03747	integrating conjugative element membrane protein, PFL_4697 family
+conj_PilL	TIGR03748	integrating conjugative element protein PilL, PFGI-1 class
+conj_TIGR03749	TIGR03749	integrating conjugative element protein, PFL_4704 family
+conj_TIGR03750	TIGR03750	conjugative transfer region protein, TIGR03750 family
+conj_TIGR03751	TIGR03751	conjugative transfer region lipoprotein, TIGR03751 family
+conj_TIGR03752	TIGR03752	integrating conjugative element protein, PFL_4705 family
+blh_monoox	TIGR03753	beta-carotene 15,15'-monooxygenase, Brp/Blh family
+conj_TOL_TraD	TIGR03754	conjugative coupling factor TraD, PFGI-1 class
+conj_TIGR03755	TIGR03755	integrating conjugative element protein, PFL_4711 family
+conj_TIGR03756	TIGR03756	integrating conjugative element protein, PFL_4710 family
+conj_TIGR03757	TIGR03757	integrating conjugative element protein, PFL_4709 family
+conj_TIGR03758	TIGR03758	integrating conjugative element protein, PFL_4701 family
+conj_TIGR03759	TIGR03759	integrating conjugative element protein, PFL_4693 family
+ICE_TraI_Pfluor	TIGR03760	integrating conjugative element relaxase, PFGI-1 class
+ICE_PFL4669	TIGR03761	integrating conjugative element protein, PFL_4669 family
+archaeo_artC	TIGR03762	archaeosortase C
+cyanoexo_CrtA	TIGR03763	cyanoexosortase A
+ICE_PFGI_1_parB	TIGR03764	integrating conjugative element, PFGI_1 class, ParB family protein
+ICE_PFL_4695	TIGR03765	integrating conjugative element protein, PFL_4695 family
+TIGR03766	TIGR03766	conserved hypothetical integral membrane protein
+P_acnes_RR	TIGR03767	metallophosphoesterase, PPA1498 family
+RPA4764	TIGR03768	metallophosphoesterase, RPA4764 family
+P_ac_wall_RPT	TIGR03769	actinobacterial surface-anchored protein domain
+anch_rpt_perm	TIGR03770	anchored repeat-type ABC transporter, permease subunit
+anch_rpt_ABC	TIGR03771	anchored repeat-type ABC transporter, ATP-binding subunit
+anch_rpt_subst	TIGR03772	anchored repeat ABC transporter, substrate-binding protein
+anch_rpt_wall	TIGR03773	putative ABC transporter-associated repeat protein
+RPE2	TIGR03774	rickettsial palindromic element RPE2 domain
+RPE3	TIGR03775	rickettsial palindromic element RPE3 domain
+RPE5	TIGR03776	rickettsial palindromic element RPE5 domain
+RPE4	TIGR03777	rickettsial palindromic element RPE4 domain
+VPDSG_CTERM	TIGR03778	VPDSG-CTERM protein sorting domain
+Bac_Flav_CT_M	TIGR03779	Bacteroides conjugative transposon TraM protein
+Bac_Flav_CT_N	TIGR03780	Bacteroides conjugative transposon TraN protein
+Bac_Flav_CT_K	TIGR03781	Bacteroides conjugative transposon TraK protein
+Bac_Flav_CT_J	TIGR03782	Bacteroides conjugative transposon TraJ protein
+Bac_Flav_CT_G	TIGR03783	Bacteroides conjugation system ATPase, TraG family
+marine_sortase	TIGR03784	sortase, marine proteobacterial type
+marine_sort_HK	TIGR03785	proteobacterial dedicated sortase system histidine kinase
+strep_pil_rpt	TIGR03786	streptococcal pilin isopeptide linkage domain
+marine_sort_RR	TIGR03787	proteobacterial dedicated sortase system response regulator
+marine_srt_targ	TIGR03788	marine proteobacterial sortase target protein
+pdsO	TIGR03789	proteobacterial sortase system peptidoglycan-associated protein
+TIGR03790	TIGR03790	TIGR03790 family protein
+TTQ_mauG	TIGR03791	tryptophan tryptophylquinone biosynthesis enzyme MauG
+TIGR03792	TIGR03792	uncharacterized cyanobacterial protein, TIGR03792 family
+TOMM_pelo	TIGR03793	NHLP leader peptide domain
+NHLM_micro_HlyD	TIGR03794	NHLM bacteriocin system secretion protein
+RNP_Burkhold	TIGR03795	ribosomal natural product, two-chain TOMM family
+NHLM_micro_ABC1	TIGR03796	NHLM bacteriocin system ABC transporter, peptidase/ATP-binding protein
+NHLM_micro_ABC2	TIGR03797	NHLM bacteriocin system ABC transporter, ATP-binding protein
+ocin_TIGR03798	TIGR03798	nif11-like leader peptide domain
+NOD_PanD_pyr	TIGR03799	putative pyridoxal-dependent aspartate 1-decarboxylase
+PLP_synth_Pdx2	TIGR03800	pyridoxal 5'-phosphate synthase, glutaminase subunit Pdx2
+asp_4_decarbox	TIGR03801	aspartate 4-decarboxylase
+Asp_Ala_antiprt	TIGR03802	aspartate-alanine antiporter
+Gloeo_Verruco	TIGR03803	gloeo_Verruco repeat
+para_beta_helix	TIGR03804	parallel beta-helix repeat
+beta_helix_1	TIGR03805	parallel beta-helix repeat-containing protein
+chp_HNE_0200	TIGR03806	conserved hypothetical protein, HNE_0200 family
+RR_fam_repeat	TIGR03807	putative cofactor-binding repeat
+RR_plus_rpt_1	TIGR03808	twin-arg-translocated uncharacterized repeat protein
+TIGR03809	TIGR03809	TIGR03809 family protein
+arg_ornith_anti	TIGR03810	arginine-ornithine antiporter
+tyr_de_CO2_Ent	TIGR03811	tyrosine decarboxylase
+tyr_de_CO2_Arch	TIGR03812	tyrosine decarboxylase MnfA
+put_Glu_GABA_T	TIGR03813	putative glutamate/gamma-aminobutyrate antiporter
+Gln_ase	TIGR03814	glutaminase A
+CpaE_hom_Actino	TIGR03815	helicase/secretion neighborhood CpaE-like protein
+tadE_like_DECH	TIGR03816	helicase/secretion neighborhood TadE-like protein
+DECH_helic	TIGR03817	helicase/secretion neighborhood putative DEAH-box helicase
+MotA1	TIGR03818	flagellar motor stator protein MotA
+heli_sec_ATPase	TIGR03819	helicase/secretion neighborhood ATPase
+lys_2_3_AblA	TIGR03820	lysine-2,3-aminomutase
+EFP_modif_epmB	TIGR03821	EF-P beta-lysylation protein EpmB
+AblA_like_2	TIGR03822	lysine-2,3-aminomutase-related protein
+FliZ	TIGR03823	flagellar regulatory protein FliZ
+FlgM_jcvi	TIGR03824	flagellar biosynthesis anti-sigma factor FlgM
+FliH_bacil	TIGR03825	flagellar assembly protein FliH
+YvyF	TIGR03826	flagellar operon protein TIGR03826
+GNAT_ablB	TIGR03827	putative beta-lysine N-acetyltransferase
+pfkB	TIGR03828	1-phosphofructokinase
+YokU_near_AblA	TIGR03829	uncharacterized protein, YokU family
+CxxCG_CxxCG_HTH	TIGR03830	putative zinc finger/helix-turn-helix protein, YgiT family
+YgiT_finger	TIGR03831	YgiT-type zinc finger domain
+Tyr_2_3_mutase	TIGR03832	tyrosine 2,3-aminomutase
+TIGR03833	TIGR03833	conserved hypothetical protein
+EAGR_box	TIGR03834	EAGR box
+termin_org_DnaJ	TIGR03835	terminal organelle assembly protein TopJ
+termin_org_HMW1	TIGR03836	cytadherence high molecular weight protein 1 N-terminal region
+efp_adjacent_2	TIGR03837	conserved hypothetical protein, PP_1857 family
+queuosine_YadB	TIGR03838	glutamyl-queuosine tRNA(Asp) synthetase
+termin_org_P1	TIGR03839	adhesin P1
+TMPT_Se_Te	TIGR03840	thiopurine S-methyltransferase, Se/Te detoxification family
+F420_Rv3093c	TIGR03841	probable F420-dependent oxidoreductase, Rv3093c family
+F420_CPS_4043	TIGR03842	F420-dependent oxidoreductase, CPS_4043 family
+TIGR03843	TIGR03843	conserved hypothetical protein
+cysteate_syn	TIGR03844	cysteate synthase
+sulfopyru_alph	TIGR03845	sulfopyruvate decarboxylase, alpha subunit
+sulfopy_beta	TIGR03846	sulfopyruvate decarboxylase, beta subunit
+TIGR03847	TIGR03847	conserved hypothetical protein
+MSMEG_4193	TIGR03848	probable phosphomutase, MSMEG_4193 family
+arch_ComA	TIGR03849	phosphosulfolactate synthase
+bind_CPR_0540	TIGR03850	carbohydrate ABC transporter substrate-binding protein, CPR_0540 family
+chitin_NgcE	TIGR03851	carbohydrate ABC transporter, N-acetylglucosamine/diacetylchitobiose-binding protein
+sucrose_gtfA	TIGR03852	sucrose phosphorylase
+matur_matur	TIGR03853	putative metal-binding protein
+F420_MSMEG_3544	TIGR03854	probable F420-dependent oxidoreductase, MSMEG_3544 family
+NAD_NadX	TIGR03855	aspartate dehydrogenase
+F420_MSMEG_2906	TIGR03856	probable F420-dependent oxidoreductase, MSMEG_2906 family
+F420_MSMEG_2249	TIGR03857	probable F420-dependent oxidoreductase, MSMEG_2249 family
+LLM_2I7G	TIGR03858	probable oxidoreductase, LLM family
+PQQ_PqqD	TIGR03859	coenzyme PQQ biosynthesis protein PqqD
+FMN_nitrolo	TIGR03860	FMN-dependent oxidoreductase, nitrilotriacetate monooxygenase family
+phenyl_ABC_PedC	TIGR03861	alcohol ABC transporter, permease protein
+flavo_PP4765	TIGR03862	flavoprotein, TIGR03862 family
+PQQ_ABC_bind	TIGR03863	ABC transporter, substrate binding protein, PQQ-dependent alcohol dehydrogenase system
+PQQ_ABC_ATP	TIGR03864	ABC transporter, ATP-binding subunit, PQQ-dependent alcohol dehydrogenase system
+PQQ_CXXCW	TIGR03865	PQQ-dependent catabolism-associated CXXCW motif protein
+PQQ_ABC_repeats	TIGR03866	PQQ-dependent catabolism-associated beta-propeller protein
+MprA_tail	TIGR03867	MprA protease C-terminal rhombosortase-interaction domain
+F420-O_ABCperi	TIGR03868	proposed F420-0 ABC transporter, periplasmic F420-0 binding protein
+F420-0_ABCperm	TIGR03869	proposed F420-0 ABC transporter, permease protein
+ABC_MoxJ	TIGR03870	methanol oxidation system protein MoxJ
+ABC_peri_MoxJ_2	TIGR03871	quinoprotein dehydrogenase-associated probable ABC transporter substrate-binding protein
+cytochrome_MoxG	TIGR03872	cytochrome c(L), periplasmic
+F420-0_ABC_ATP	TIGR03873	proposed F420-0 ABC transporter, ATP-binding protein
+4cys_cytochr	TIGR03874	c-type cytochrome, methanol metabolism-related
+RNA_lig_partner	TIGR03875	RNA ligase partner, MJ_0950 family
+cas_csaX	TIGR03876	CRISPR type I-A/APERN-associated protein CsaX
+thermo_KaiC_1	TIGR03877	KaiC domain protein, Ph0284 family
+thermo_KaiC_2	TIGR03878	KaiC domain protein, AF_0795 family
+near_KaiC_dom	TIGR03879	probable regulatory domain
+KaiC_arch_3	TIGR03880	KaiC domain protein, AF_0351 family
+KaiC_arch_4	TIGR03881	KaiC domain protein, PAE1156 family
+cyclo_dehyd_2	TIGR03882	bacteriocin biosynthesis cyclodehydratase domain
+DUF2342_F420	TIGR03883	uncharacterized protein, coenzyme F420 biosynthesis associated
+sel_bind_Methan	TIGR03884	selenium-binding protein
+flavin_revert	TIGR03885	probable non-F420 flavinoid oxidoreductase
+lyase_spl_fam	TIGR03886	spore photoproduct lyase family protein
+thiocyan_alph	TIGR03887	thiocyanate hydrolase, gamma subunit
+nitrile_beta	TIGR03888	nitrile hydratase, beta subunit
+nitrile_acc	TIGR03889	nitrile hydratase accessory protein
+nif11_cupin	TIGR03890	nif11 domain/cupin domain protein
+thiopep_ocin	TIGR03891	thiopeptide-type bacteriocin biosynthesis domain
+thiopep_precurs	TIGR03892	thiazolylpeptide-type bacteriocin precursor
+lant_SP_1948	TIGR03893	type 2 lantibiotic, SP_1948 family
+chp_P_marinus_1	TIGR03894	conserved hypothetical protein, TIGR03894 family
+protease_PatA	TIGR03895	cyanobactin maturation protease, PatA/PatG family
+cyc_nuc_ocin	TIGR03896	bacteriocin-type transport-associated protein
+lanti_2_LanM	TIGR03897	type 2 lantibiotic biosynthesis protein LanM
+lanti_MRSA_kill	TIGR03898	type 2 lantibiotic, mersacidin/lichenicidin family
+TIGR03899	TIGR03899	TIGR03899 family protein
+prc_long_Delta	TIGR03900	putative carboxyl-terminal-processing protease, deltaproteobacterial
+MYXO-CTERM	TIGR03901	MYXO-CTERM domain
+rhom_GG_sort	TIGR03902	rhombosortase
+TOMM_kin_cyc	TIGR03903	TOMM system kinase/cyclase fusion protein
+SAM_YgiQ	TIGR03904	uncharacterized radical SAM protein YgiQ
+TIGR03905_4_Cys	TIGR03905	uncharacterized protein TIGR03905
+quino_hemo_SAM	TIGR03906	quinohemoprotein amine dehydrogenase maturation protein
+QH_beta	TIGR03907	quinohemoprotein amine dehydrogenase, beta subunit
+QH_alpha	TIGR03908	quinohemoprotein amine dehydrogenase, alpha subunit
+pyrrolys_PylC	TIGR03909	pyrrolysine biosynthesis protein PylC
+pyrrolys_PylB	TIGR03910	pyrrolysine biosynthesis radical SAM protein
+pyrrolys_PylD	TIGR03911	pyrrolysine biosynthesis protein PylD
+PylS_Nterm	TIGR03912	pyrrolysine--tRNA ligase, N-terminal region
+rad_SAM_trio	TIGR03913	Y_X(10)_GDL-associated radical SAM protein
+UDG_fam_dom	TIGR03914	uracil-DNA glycosylase family domain
+SAM_7_link_chp	TIGR03915	probable DNA metabolism protein
+rSAM_link_UDG	TIGR03916	putative DNA modification/repair radical SAM protein
+Frankia_40_dom	TIGR03917	Frankia-40 domain
+GTP_HydF	TIGR03918	[FeFe] hydrogenase H-cluster maturation GTPase HydF
+T7SS_EccB	TIGR03919	type VII secretion protein EccB
+T7SS_EccD	TIGR03920	type VII secretion integral membrane protein EccD
+T7SS_mycosin	TIGR03921	type VII secretion-associated serine protease mycosin
+T7SS_EccA	TIGR03922	type VII secretion AAA-ATPase EccA
+T7SS_EccE	TIGR03923	type VII secretion protein EccE
+T7SS_EccC_a	TIGR03924	type VII secretion protein EccCa
+T7SS_EccC_b	TIGR03925	type VII secretion protein EccCb
+T7_EssB	TIGR03926	type VII secretion protein EssB
+T7SS_EssA_Firm	TIGR03927	type VII secretion protein EssA
+T7_EssCb_Firm	TIGR03928	type VII secretion protein EssC
+T7_esaA_Nterm	TIGR03929	type VII secretion protein EsaA
+WXG100_ESAT6	TIGR03930	WXG100 family type VII secretion target
+T7SS_Rv3446c	TIGR03931	type VII secretion-associated protein, Rv3446c family
+PIA_icaD	TIGR03932	intracellular adhesion protein D
+PIA_icaB	TIGR03933	intercellular adhesin biosynthesis polysaccharide N-deacetylase
+TQXA_dom	TIGR03934	TQXA domain
+fragilysin	TIGR03935	fragilysin
+sam_1_link_chp	TIGR03936	radical SAM-linked protein
+PgaC_IcaA	TIGR03937	poly-beta-1,6 N-acetyl-D-glucosamine synthase
+deacetyl_PgaB	TIGR03938	poly-beta-1,6-N-acetyl-D-glucosamine N-deacetylase PgaB
+PGA_TPR_OMP	TIGR03939	poly-beta-1,6 N-acetyl-D-glucosamine export porin PgaA
+PGA_PgaD	TIGR03940	poly-beta-1,6-N-acetyl-D-glucosamine biosynthesis protein PgaD
+tRNA_deam_assoc	TIGR03941	putative tRNA adenosine deaminase-associated protein
+sulfatase_rSAM	TIGR03942	anaerobic sulfatase maturase
+TIGR03943	TIGR03943	TIGR03943 family protein
+dehyd_SbnB_fam	TIGR03944	2,3-diaminopropionate biosynthesis protein SbnB
+PLP_SbnA_fam	TIGR03945	2,3-diaminopropionate biosynthesis protein SbnA
+viomycin_VioC	TIGR03946	arginine beta-hydroxylase, Fe(II)/alpha-ketoglutarate-dependent
+viomycin_VioD	TIGR03947	capreomycidine synthase
+butyr_acet_CoA	TIGR03948	butyryl-CoA:acetate CoA-transferase
+bact_IIb_cerein	TIGR03949	class IIb bacteriocin, lactobin A/cerein 7B family
+sidero_Fe_reduc	TIGR03950	siderophore ferric iron reductase, AHA_1954 family
+Fe_III_red_FhuF	TIGR03951	siderophore-iron reductase FhuF
+metzin_BF0631	TIGR03952	zinc-dependent metalloproteinase lipoprotein, BF0631 family
+rplD_bact	TIGR03953	50S ribosomal protein uL4
+integ_memb_HG	TIGR03954	integral membrane protein
+rSAM_HydG	TIGR03955	[FeFe] hydrogenase H-cluster radical SAM maturase HydG
+rSAM_HydE	TIGR03956	[FeFe] hydrogenase H-cluster radical SAM maturase HydE
+rSAM_HmdB	TIGR03957	5,10-methenyltetrahydromethanopterin hydrogenase cofactor biosynthesis protein HmdB
+monoFe_hyd_HmdC	TIGR03958	5,10-methenyltetrahydromethanopterin hydrogenase cofactor biosynthesis protein HmdC
+hyd_TM1266	TIGR03959	putative iron-only hydrogenase system regulator
+rSAM_fuse_unch	TIGR03960	radical SAM family uncharacterized protein
+rSAM_PTO1314	TIGR03961	archaeal radical SAM protein, PTO1314 family
+mycofact_rSAM	TIGR03962	mycofactocin radical SAM maturase
+rSAM_QueE_Clost	TIGR03963	putative 7-cyano-7-deazaguanosine (preQ0) biosynthesis protein QueE
+mycofact_creat	TIGR03964	mycofactocin system creatininase family protein
+mycofact_glyco	TIGR03965	mycofactocin system glycosyltransferase
+actino_HemFlav	TIGR03966	heme/flavin dehydrogenase, mycofactocin system
+mycofact_MftB	TIGR03967	putative mycofactocin binding protein MftB
+mycofact_TetR	TIGR03968	mycofactocin system transcriptional regulator
+mycofactocin	TIGR03969	mycofactocin precursor
+Rv0697	TIGR03970	dehydrogenase, Rv0697 family
+SDR_subfam_1	TIGR03971	SDR family mycofactocin-dependent oxidoreductase
+rSAM_TYW1	TIGR03972	wyosine biosynthesis protein TYW1
+six_Cys_in_45	TIGR03973	six-cysteine peptide SCIFF
+rSAM_six_Cys	TIGR03974	SCIFF radical SAM maturase
+rSAM_ocin_1	TIGR03975	ribosomal peptide maturation radical SAM protein 1
+chp_LLNDYxLRE	TIGR03976	His-Xaa-Ser system protein HxsD
+rSAM_pair_HxsC	TIGR03977	His-Xaa-Ser system radical SAM maturase HxsC
+rSAM_paired_1	TIGR03978	His-Xaa-Ser system radical SAM maturase HxsB
+His_Ser_Rich	TIGR03979	His-Xaa-Ser repeat protein HxsA
+prismane_assoc	TIGR03980	hybrid cluster protein-associated redox disulfide domain
+SAM_quin_mod	TIGR03981	His-Xaa-Ser system putative quinone modification maturase
+TIGR03982	TIGR03982	His-Xaa-Ser system protein, TIGR03982 family
+cas1_MYXAN	TIGR03983	CRISPR-associated endonuclease Cas1, subtype MYXAN
+TIGR03984	TIGR03984	CRISPR-associated protein, TIGR03984 family
+TIGR03985	TIGR03985	CRISPR-associated protein, TIGR03985 family
+TIGR03986	TIGR03986	CRISPR-associated protein
+TIGR03987	TIGR03987	TIGR03987 family protein
+antisig_RsrA	TIGR03988	mycothiol system anti-sigma-R factor
+Rxyl_3153	TIGR03989	NDMA-dependent alcohol dehydrogenase, Rxyl_3153 family
+Arch_GlmM	TIGR03990	phosphoglucosamine mutase
+alt_bact_glmU	TIGR03991	UDP-N-acetylglucosamine diphosphorylase/glucosamine-1-phosphate N-acetyltransferase
+Arch_glmU	TIGR03992	UDP-N-acetylglucosamine diphosphorylase/glucosamine-1-phosphate N-acetyltransferase
+hydrog_HybE	TIGR03993	[NiFe] hydrogenase assembly chaperone, HybE family
+rSAM_HemZ	TIGR03994	coproporphyrinogen dehydrogenase HemZ
+target_X_rSAM	TIGR03995	putative rSAM target protein, CGCGG family
+mycofact_OYE_1	TIGR03996	mycofactocin system FadH/OYE family oxidoreductase 1
+mycofact_OYE_2	TIGR03997	mycofactocin system FadH/OYE family oxidoreductase 2
+thiol_BshC	TIGR03998	bacillithiol biosynthesis cysteine-adding enzyme BshC
+thiol_BshA	TIGR03999	N-acetyl-alpha-D-glucosaminyl L-malate synthase BshA
+thiol_BshB2	TIGR04000	bacillithiol biosynthesis deacetylase BshB2
+thiol_BshB1	TIGR04001	bacillithiol biosynthesis deacetylase BshB1
+TIGR04002	TIGR04002	TIGR04002 family protein
+rSAM_BssD	TIGR04003	[benzylsuccinate synthase]-activating enzyme
+WcaM	TIGR04004	colanic acid biosynthesis protein WcaM
+wcaL	TIGR04005	colanic acid biosynthesis glycosyltransferase WcaL
+wcaK	TIGR04006	colanic acid biosynthesis pyruvyl transferase WcaK
+wcaI	TIGR04007	colanic acid biosynthesis glycosyltransferase WcaI
+WcaF	TIGR04008	colanic acid biosynthesis acetyltransferase WcaF
+wcaE	TIGR04009	colanic acid biosynthesis glycosyltransferase WcaE
+WcaD	TIGR04010	putative colanic acid polymerase WcaD
+poly_gGlu_PgsC	TIGR04011	poly-gamma-glutamate biosynthesis protein PgsC
+poly_gGlu_PgsB	TIGR04012	poly-gamma-glutamate synthase PgsB
+B12_SAM_MJ_1487	TIGR04013	B12-binding domain/radical SAM domain protein, MJ_1487 family
+B12_SAM_MJ_0865	TIGR04014	B12-binding domain/radical SAM domain protein, MJ_0865 family
+WcaC	TIGR04015	colanic acid biosynthesis glycosyltransferase WcaC
+WcaB	TIGR04016	colanic acid biosynthesis acetyltransferase WcaB
+WcaA	TIGR04017	colanic acid biosynthesis glycosyltransferase WcaA
+Bthiol_YpdA	TIGR04018	putative bacillithiol system oxidoreductase, YpdA family
+B_thiol_YtxJ	TIGR04019	bacillithiol system protein YtxJ
+seco_metab_LLM	TIGR04020	natural product biosynthesis luciferase-like monooxygenase domain
+LLM_DMSO2_sfnG	TIGR04021	dimethyl sulfone monooxygenase SfnG
+sulfur_SfnB	TIGR04022	sulfur acquisition oxidoreductase, SfnB family
+PPOX_MSMEG_5819	TIGR04023	PPOX class F420-dependent enzyme, MSMEG_5819/OxyR family
+F420_NP1902A	TIGR04024	coenzyme F420-dependent oxidoreductase, NP1902A family
+PPOX_FMN_DR2398	TIGR04025	pyridoxamine 5'-phosphate oxidase, FMN-binding family
+PPOX_FMN_cyano	TIGR04026	PPOX class probable FMN-dependent enzyme, alr4036 family
+LLM_KPN_01858	TIGR04027	putative FMN-dependent luciferase-like monooxygenase, KPN_01858 family
+SBP_KPN_01854	TIGR04028	ABC transporter substrate binding protein, KPN_01854 family
+CMD_Avi_7170	TIGR04029	CMD domain protein, Avi_7170 family
+perox_Avi_7169	TIGR04030	alkylhydroperoxidase domain protein, Avi_7169 family
+Htur_1727_fam	TIGR04031	rSAM-partnered protein, Htur_1727 family
+toxin_SdpC	TIGR04032	antimicrobial peptide, SdpC family
+export_SdpB	TIGR04033	antimicrobial peptide system protein, SdpB family
+export_SdpA	TIGR04034	antimicrobial peptide system protein, SdpA family
+glucan_65_rpt	TIGR04035	glucan-binding repeat
+LLM_CE1758_fam	TIGR04036	putative luciferase-like monooxygenase, FMN-dependent, CE1758 family
+LLM_duo_CE1759	TIGR04037	LLM-partnered FMN reductase, CE1759 family
+tatD_link_rSAM	TIGR04038	radical SAM protein, TatD family-associated
+MXAN_0977_Heme2	TIGR04039	di-heme enzyme, MXAN_0977 family
+glycyl_YjjI	TIGR04040	glycine radical enzyme, YjjI family
+activase_YjjW	TIGR04041	glycine radical enzyme activase, YjjW family
+MSMEG_0570_fam	TIGR04042	MSMEG_0570 family protein
+rSAM_MSMEG_0568	TIGR04043	radical SAM protein, MSMEG_0568 family
+MSMEG_0572_fam	TIGR04044	MSMEG_0572 family protein
+MSMEG_0567_GNAT	TIGR04045	putative N-acetyltransferase, MSMEG_0567 N-terminal domain family
+MSMEG_0569_nitr	TIGR04046	flavin-dependent oxidoreductase, MSMEG_0569 family
+MSMEG_0565_glyc	TIGR04047	glycosyltransferase, MSMEG_0565 family
+nitrile_sll0784	TIGR04048	putative nitrilase, sll0784 family
+AIR_rel_sll0787	TIGR04049	AIR synthase-related protein, sll0787 family
+MSMEG_0567_Cter	TIGR04050	AIR synthase-related protein, MSMEG_0567 C-terminal family
+rSAM_NirJ	TIGR04051	heme d1 biosynthesis radical SAM protein NirJ
+AZL_007920_fam	TIGR04052	AZL_007920/MXAN_0976 family protein
+sam_11	TIGR04053	radical SAM protein, BA_1875 family
+rSAM_NirJ1	TIGR04054	putative heme d1 biosynthesis radical SAM protein NirJ1
+rSAM_NirJ2	TIGR04055	putative heme d1 biosynthesis radical SAM protein NirJ2
+OMP_RagA_SusC	TIGR04056	TonB-linked outer membrane protein, SusC/RagA family
+SusC_RagA_signa	TIGR04057	TonB-dependent outer membrane receptor, SusC/RagA subfamily, signature region
+AcACP_reductase	TIGR04058	long-chain fatty acyl-ACP reductase (aldehyde-forming)
+Ald_deCOase	TIGR04059	long-chain fatty aldehyde decarbonylase
+formate_focA	TIGR04060	formate transporter FocA
+AZL_007950_fam	TIGR04061	AZL_007950 family protein
+dnd_assoc_4	TIGR04062	dnd system-associated protein 4
+stp3	TIGR04063	PEP-CTERM/exosortase A-associated glycosyltransferase, Daro_2409 family
+rSAM_nif11	TIGR04064	nif11-like peptide radical SAM maturase
+ocin_CLI_3235	TIGR04065	putative bacteriocin precursor, CLI_3235 family
+nat_prod_clost	TIGR04066	peptide maturation system protein, TIGR04066 family
+oc_CLOSPO_01332	TIGR04067	putative bacteriocin precursor, CLOSPO_01332 family
+rSAM_ocin_clost	TIGR04068	Cys-rich peptide radical SAM maturase CcpM
+ocin_ACP_rel	TIGR04069	peptide maturation system acyl carrier-related protein
+photo_TT_lyase	TIGR04070	spore photoproduct lyase
+methanobac_OB3b	TIGR04071	methanobactin precursor, Mb-OB3b family
+rSAM_ladder_B12	TIGR04072	lipid biosynthesis B12-binding/radical SAM protein
+exo_TIGR04073	TIGR04073	putative exosortase-associated protein, TIGR04073 family
+bacter_Hen1	TIGR04074	3' terminal RNA ribose 2'-O-methyltransferase Hen1
+bacter_Pnkp	TIGR04075	polynucleotide kinase-phosphatase
+TIGR04076	TIGR04076	TIGR04076 family protein
+expor_sig_YdyF	TIGR04077	exported signaling peptide, YydF/SAG_2028 family
+rSAM_yydG	TIGR04078	peptide modification radical SAM enzyme, YydG family
+phero_cyc_pep	TIGR04079	KxxxW-cyclized secreted peptide
+rSAM_pep_cyc	TIGR04080	KxxxW cyclic peptide radical SAM maturase
+selen_ocin	TIGR04081	radical SAM modification target peptide, selenobiotic family
+rSAM_for_selen	TIGR04082	selenobiotic family peptide radical SAM maturase
+rSAM_pep_methan	TIGR04083	putative peptide-modifying radical SAM enzyme, Mhun_1560 family
+rSAM_AF0577	TIGR04084	putative peptide-modifying radical SAM enzyme, AF0577 family
+rSAM_more_4Fe4S	TIGR04085	radical SAM additional 4Fe4S-binding SPASM domain
+TIGR04086_membr	TIGR04086	putative membrane protein, TIGR04086 family
+YqxM_for_SipW	TIGR04087	YqxM protein
+cognate_SipW	TIGR04088	SipW-cognate class signal peptide
+exp_by_SipW_III	TIGR04089	alternate signal-mediated exported protein, RER_14450 family
+exp_by_SipW_IV	TIGR04090	alternate signal-mediated exported protein, CPF_0494 family
+LTA_dltB	TIGR04091	D-alanyl-lipoteichoic acid biosynthesis protein DltB
+LTA_DltD	TIGR04092	D-alanyl-lipoteichoic acid biosynthesis protein DltD
+cas1_CYANO	TIGR04093	CRISPR-associated endonuclease Cas1, subtype CYANO
+adjacent_YSIRK	TIGR04094	YSIRK-targeted surface antigen transcriptional regulator
+dnd_restrict_1	TIGR04095	DNA phosphorothioation system restriction enzyme
+dnd_rel_methyl	TIGR04096	DNA phosphorothioation-associated putative methyltransferase
+biosyn_clust_1	TIGR04098	biosynthesis cluster domain
+biosn_Pnap_2097	TIGR04099	probable biosynthetic protein, Pnap_2097 family
+rSAM_pair_X	TIGR04100	radical SAM enzyme, TIGR04100 family
+CCGSCS	TIGR04101	CCGSCS motif protein
+SWIM_PBPRA1643	TIGR04102	SWIM/SEC-C metal-binding motif protein, PBPRA1643 family
+rSAM_nif11_3	TIGR04103	nif11-class peptide radical SAM maturase 3
+cxxc_20_cxxc	TIGR04104	cxxc_20_cxxc protein
+FeFe_hydrog_B1	TIGR04105	[FeFe] hydrogenase, group B1/B3
+cas8c_GSU0052	TIGR04106	CRISPR-associated protein GSU0052/csb3, Dpsyc system
+rSAM_HutW	TIGR04107	putative heme utilization radical SAM enzyme HutW
+HutX	TIGR04108	putative heme utilization carrier protein HutX
+heme_ox_HugZ	TIGR04109	heme oxygenase, HugZ family
+heme_HutZ	TIGR04110	heme utilization protein HutZ
+BcepMu_gp16	TIGR04111	phage-associated protein, BcepMu gp16 family
+seleno_YedE	TIGR04112	putative selenium metabolism protein, YedE family
+cas_csx17	TIGR04113	CRISPR-associated protein Csx17, subtype Dpsyc
+tSAM_targ_Cxxx	TIGR04114	modification target Cys-rich repeat
+rSAM_Cxxx_rpt	TIGR04115	radical SAM peptide maturase, CXXX-repeat target family
+CXXX_rpt_assoc	TIGR04116	CXXX repeat peptide modification system protein
+Syntroph_Cxxx	TIGR04117	Cys-Xaa-Xaa-Xaa repeat radical SAM target protein
+Cxxx_AC3_0185	TIGR04118	modification target Cys-rich peptide, AC3_0185 family
+CXXX_matur	TIGR04119	CXXX repeat peptide maturase
+DNA_lig_bact	TIGR04120	DNA ligase, ATP-dependent, PP_1105 family
+DEXH_lig_assoc	TIGR04121	DEXH box helicase, DNA ligase-associated
+Xnuc_lig_assoc	TIGR04122	putative exonuclease, DNA ligase-associated
+P_estr_lig_assc	TIGR04123	metallophosphoesterase, DNA ligase-associated
+archaeo_artE	TIGR04124	archaeosortase family protein ArtE
+exosort_PGF_TRM	TIGR04125	archaeosortase A
+PGF_CTERM	TIGR04126	PGF-CTERM archaeal protein-sorting signal
+flavo_near_exo	TIGR04127	exosortase F-associated protein
+exoso_Fjoh_1448	TIGR04128	exosortase family protein XrtF
+CxxH_BA5709	TIGR04129	CxxH/CxxC protein, BA_5709 family
+FnlA	TIGR04130	UDP-N-acetylglucosamine 4,6-dehydratase/5-epimerase
+Bac_Flav_CTERM	TIGR04131	gliding motility-associated C-terminal domain
+intra_fol_E_lig	TIGR04132	putative folate metabolism gamma-glutamate ligase
+rSAM_w_lipo	TIGR04133	radical SAM enzyme, rSAM/lipoprotein system
+lipo_with_rSAM	TIGR04134	putative lipoprotein, rSAM/lipoprotein system
+FibroRuminTarg	TIGR04135	Cys-rich radical SAM target, FibroRumin family
+rSAM_FibroRumin	TIGR04136	radical SAM peptide maturase, FibroRumin system
+Chlam_Ver_rRNA	TIGR04137	Chlam_Verruc_Plancto small basic protein
+Plancto_Ver_chp	TIGR04138	Verruc_Plancto-restricted protein
+CxxCx5CxxC_targ	TIGR04139	putative peptide modification target, TIGR04139 family
+chp_AF_0576	TIGR04140	TIGR04140 family protein
+TIGR04141	TIGR04141	sporadically distributed protein, TIGR04141 family
+PCisTranLspir	TIGR04142	putative peptidyl-prolyl cis-trans isomerase, LIC12922 family
+VPxxxP_CTERM	TIGR04143	VPXXXP-CTERM protein sorting domain
+archaeo_VPXXXP	TIGR04144	archaeosortase B
+Firmicu_CTERM	TIGR04145	Firmicu-CTERM domain
+GGGPS_Afulg	TIGR04146	phosphoglycerol geranylgeranyltransferase
+GGGPS_Halobact	TIGR04147	phosphoglycerol geranylgeranyltransferase, putative
+GG_samocin_CFB	TIGR04148	radical SAM peptide maturase, GG-Bacteroidales family
+GG_sam_targ_CFB	TIGR04149	natural product precursor, GG-Bacteroidales family
+pseudo_rSAM_GG	TIGR04150	pseudo-rSAM protein, GG-Bacteroidales system
+exosort_VPDSG	TIGR04151	exosortase C, VPDSG-CTERM-specific
+exosort_VPLPA	TIGR04152	exosortase D, VPLPA-CTERM-specific
+cyanosortA_assc	TIGR04153	cyanosortase A-associated protein
+archaeo_STT3	TIGR04154	oligosaccharyl transferase, archaeosortase A system-associated
+cyano_PEP	TIGR04155	PEP-CTERM protein sorting domain, cyanobacterial subclass
+cyanoexo_CrtB	TIGR04156	cyanoexosortase B
+glyco_rSAM_CFB	TIGR04157	glycosyltransferase, GG-Bacteroidales peptide system
+rSAM_MIA_synth	TIGR04158	3-methyl-2-indolic acid synthase
+methbact_MbnB	TIGR04159	methanobactin biosynthesis cassette protein MbnB
+methbact_MbnC	TIGR04160	methanobactin biosynthesis cassette protein MbnC
+VPEID-CTERM	TIGR04161	VPEID-CTERM protein sorting domain
+exo_VPEID	TIGR04162	exosortase E/protease, VPEID-CTERM system
+rSAM_cobopep	TIGR04163	peptide-modifying radical SAM enzyme CbpB
+cobo_pep	TIGR04164	modified peptide precursor CbpA
+methano_modCys	TIGR04165	Cys-rich peptide, TIGR04165 family
+methano_MtrB	TIGR04166	tetrahydromethanopterin S-methyltransferase, subunit B
+rSAM_SeCys	TIGR04167	radical SAM/Cys-rich domain protein
+TIGR04168	TIGR04168	TIGR04168 family protein
+perox_w_seleSAM	TIGR04169	alkylhydroperoxidase/carboxymuconolactone decarboxylase family protein
+RNR_1b_NrdE	TIGR04170	ribonucleoside-diphosphate reductase, class 1b, alpha subunit
+RNR_1b_NrdF	TIGR04171	ribonucleoside-diphosphate reductase, class 1b, beta subunit
+DGQHR_dnd_1	TIGR04172	DNA phosphorothioation-associated DGQHR protein 1
+PIP_CTERM	TIGR04173	PIP-CTERM protein sorting domain
+IPTL_CTERM	TIGR04174	IPTL-CTERM protein sorting domain
+archaeo_artD	TIGR04175	archaeosortase D
+MarR_EPS	TIGR04176	EPS-associated transcriptional regulator, MarR family
+exosort_XrtH	TIGR04177	exosortase H, IPTLxxWG-CTERM-specific
+exo_archaeo	TIGR04178	exosortase/archaeosortase family protein
+rhombo_lipo	TIGR04179	rhombotail lipoprotein
+EDH_00030	TIGR04180	NAD dependent epimerase/dehydratase, LLPSF_EDH_00030 family
+NHT_00031	TIGR04181	aminotransferase, LLPSF_NHT_00031 family
+glyco_TIGR04182	TIGR04182	glycosyltransferase, TIGR04182 family
+Por_Secre_tail	TIGR04183	Por secretion system C-terminal sorting domain
+ATPgraspMvdD	TIGR04184	ATP-grasp ribosomal peptide maturase, MvdD family
+ATPgraspMvdC	TIGR04185	ATP-grasp ribosomal peptide maturase, MvdC family
+GRASP_targ	TIGR04186	putative ATP-grasp target RiPP
+GRASP_SAV_5884	TIGR04187	ATP-grasp ribosomal peptide maturase, SAV_5884 family
+methyltr_grsp	TIGR04188	methyltransferase, ATP-grasp peptide maturase system
+surface_SprA	TIGR04189	cell surface protein SprA
+B12_SAM_Ta0216	TIGR04190	B12-binding domain/radical SAM domain protein, Ta0216 family
+YphP_YqiW	TIGR04191	putative bacilliredoxin, YphP/YqiW family
+GRASP_w_spasm	TIGR04192	ATP-GRASP peptide maturase, grasp-with-spasm system
+SPASM_w_grasp	TIGR04193	SPASM domain peptide maturase, grasp-with-spasm system
+grasp_w_spasm_A	TIGR04194	grasp-with-spasm leader A domain
+S_glycosyl_SunS	TIGR04195	peptide S-glycosyltransferase, SunS family
+glycopep_SunS	TIGR04196	glycopeptide, sublancin family
+T7SS_SACOL2603	TIGR04197	type VII secretion effector, TIGR04197 family
+paramyx_RNAcap	TIGR04198	mRNA capping enzyme
+exosort_xrtJ	TIGR04199	exosortase J
+targ_of_XrtJ	TIGR04200	XrtJ-associated TM-motif-TM protein
+Myxo_Cys_RPT	TIGR04201	Cys-rich repeat, Myxococcales-type
+capSnatchArena	TIGR04202	RNA endonuclease, cap-snatching
+RPT_S_cricet	TIGR04203	Streptococcal surface-anchored protein repeat, S. criceti family
+MAST_ArtA_sort	TIGR04204	MAST domain
+classIII_w_PIP	TIGR04205	class III signal peptide protein, archaeosortase D/PIP-CTERM system
+near_ArtA	TIGR04206	TIGR04206 family protein
+halo_sig_pep	TIGR04207	surface glycoprotein signal peptide
+sarcinarray	TIGR04209	sarcinarray family protein
+bunya_NSm	TIGR04210	bunyavirus nonstructural protein NSm
+SH3_and_anchor	TIGR04211	SH3 domain protein
+GlyGly_RbtA	TIGR04212	rhombotarget A
+PGF_pre_PGF	TIGR04213	PGF-pre-PGF domain
+CSLREA_Nterm	TIGR04214	CSLREA domain
+choice_anch_A	TIGR04215	choice-of-anchor A domain
+halo_surf_glyco	TIGR04216	major cell surface glycoprotein
+archae_ser_T	TIGR04217	archaetidylserine synthase
+TOMM_plantaz	TIGR04218	ribosomal natural product, plantazolicin-class
+OMP_w_GlyGly	TIGR04219	outer membrane protein
+patB_acyB_mcaB	TIGR04220	cyanobactin biosynthesis protein, PatB/AcyB/McaB family
+SecA2_Mycobac	TIGR04221	accessory Sec system translocase SecA2
+near_uncomplex	TIGR04222	TIGR04222 domain
+quorum_AgrD	TIGR04223	cyclic lactone autoinducer peptide
+ser_adhes_Nterm	TIGR04224	serine-rich repeat adhesion glycoprotein
+CshA_fibril_rpt	TIGR04225	CshA-type fibril repeat
+RrgB_K2N_iso_D2	TIGR04226	fimbrial isopeptide formation D2 domain
+zmp_18_rpt	TIGR04227	zinc metalloproteinase 18-residue repeat
+isopep_sspB_C2	TIGR04228	adhesin isopeptide-forming adherence domain
+geopeptide	TIGR04229	putative radical SAM-modified peptide
+seadorna_VP11	TIGR04230	seadornavirus VP11 protein
+seadorna_VP5	TIGR04231	seadornavirus VP5 protein
+seadorna_VP3	TIGR04232	seadornavirus VP3 protein
+seadorna_VP8	TIGR04233	seadornavirus VP8 protein
+seadorna_RNAP	TIGR04234	RNA-directed RNA polymerase
+seadorna_VP4	TIGR04235	seadornavirus VP4 protein
+seadorna_VP2	TIGR04236	seadornavirus VP2 protein
+seadorna_VP9	TIGR04237	seadornavirus/coltivirus VP9 protein
+seadorna_dsRNA	TIGR04238	seadornavirus double-stranded RNA-binding protein
+rhombo_GlpG	TIGR04239	rhomboid family protease GlpG
+flavi_E_stem	TIGR04240	flavivirus envelope glycoprotein E, stem/anchor domain
+adenoE3CR1rpt	TIGR04241	mastadenovirus E3 CR1-alpha-1
+nodulat_NodC	TIGR04242	chitooligosaccharide synthase NodC
+nodulat_NodB	TIGR04243	chitooligosaccharide deacetylase NodB
+nitrous_NosZ_RR	TIGR04244	nitrous-oxide reductase, TAT-dependent
+nodulat_NodA	TIGR04245	N-acyltransferase NodA
+nitrous_NosZ_Gp	TIGR04246	nitrous-oxide reductase, Sec-dependent
+NosD_copper_fam	TIGR04247	nitrous oxide reductase family maturation protein NosD
+SCM_PqqD_rel	TIGR04248	SynChlorMet cassette protein ScmD
+SCM_chp_ScmC	TIGR04249	SynChlorMet cassette protein ScmC
+SCM_rSAM_ScmE	TIGR04250	SynChlorMet cassette radical SAM/SPASM protein ScmE
+SCM_rSAM_ScmF	TIGR04251	SynChlorMet cassette radical SAM/SPASM protein ScmF
+SCM_precur_ScmA	TIGR04252	SynChlorMet cassette protein ScmA
+mesacon_CoA_iso	TIGR04253	mesaconyl-CoA isomerase
+OpituPEPCTERM_1	TIGR04254	putative globular PEP-CTERM protein
+sporadTIGR04255	TIGR04255	TIGR04255 family protein
+GxxExxY	TIGR04256	GxxExxY protein
+nanowire_3heme	TIGR04257	c(7)-type cytochrome triheme domain
+4helix_suffix	TIGR04258	four helix bundle suffix domain
+oxa_formateAnti	TIGR04259	oxalate/formate antiporter
+Cyano_gly_rpt	TIGR04260	rSAM-associated Gly-rich repeat protein
+rSAM_GlyRichRpt	TIGR04261	radical SAM/SPASM domain protein, GRRM system
+orph_peri_GRRM	TIGR04262	extracellular substrate-binding orphan protein, GRRM family
+SasC_Mrp_aggreg	TIGR04263	SasC/Mrp/FmtB intercellular aggregation domain
+hyperosmo_Ebh	TIGR04264	hyperosmolarity resistance protein Ebh
+bac_cardiolipin	TIGR04265	cardiolipin synthase
+NDMA_methanol	TIGR04266	NDMA-dependent methanol dehydrogenase
+mod_HExxH	TIGR04267	HEXXH motif domain
+FxSxx-COOH	TIGR04268	FXSXX-COOH protein
+SAM_SPASM_FxsB	TIGR04269	radical SAM/SPASM domain protein, FxsB family
+Rama_corrin_act	TIGR04270	methylamine methyltransferase corrinoid protein reductive activase
+ThiI_C_thiazole	TIGR04271	thiazole biosynthesis domain
+cxxc_cxxc_Mbark	TIGR04272	CxxC-x17-CxxC domain
+Y_sulf_Ax21	TIGR04273	sulfation-dependent quorum factor, Ax21 family
+hypoxanDNAglyco	TIGR04274	DNA-deoxyinosine glycosylase
+beta_prop_Msarc	TIGR04275	beta propeller repeat
+FxsC_Cterm	TIGR04276	FxsC C-terminal domain
+squa_tetra_cyc	TIGR04277	tetrahymanol synthase
+viperin	TIGR04278	antiviral radical SAM protein viperin
+TIGR04279	TIGR04279	TIGR04279 domain
+geopep_mat_rSAM	TIGR04280	putative geopeptide radical SAM maturase
+peripla_PGF_1	TIGR04281	putative ABC transporter PGF-CTERM-modified substrate-binding protein
+glyco_like_cofC	TIGR04282	transferase 1, rSAM/selenodomain-associated
+glyco_like_mftF	TIGR04283	transferase 2, rSAM/selenodomain-associated
+aldehy_Rv0768	TIGR04284	aldehyde dehydrogenase, Rv0768 family
+nucleoid_noc	TIGR04285	nucleoid occlusion protein
+MSEP-CTERM	TIGR04286	MSEP-CTERM protein
+exosort_XrtK	TIGR04287	exosortase K
+CGP_CTERM	TIGR04288	CGP-CTERM domain
+heavy_Cys	TIGR04289	eight-cysteine-cluster domain
+meth_Rta_06860	TIGR04290	methyltransferase, Rta_06860 family
+arsen_driv_ArsA	TIGR04291	arsenical pump-driving ATPase
+heavy_Cys_CGP	TIGR04292	heavy-Cys/CGP-CTERM domain protein
+archaeo_artF	TIGR04293	archaeosortase family protein ArtF
+pre_pil_HX9DG	TIGR04294	prepilin-type processing-associated H-X9-DG domain
+B12_rSAM_oligo	TIGR04295	B12-binding domain/radical SAM domain protein, rhizo-twelve system
+PEFG-CTERM	TIGR04296	PEFG-CTERM domain
+thauma_sortase	TIGR04297	thaumarchaeosortase
+his_histam_anti	TIGR04298	histidine-histamine antiporter
+antiport_PotE	TIGR04299	putrescine-ornithine antiporter
+exosort_XrtM	TIGR04300	exosortase family protein XrtM
+ODC_inducible	TIGR04301	ornithine decarboxylase SpeF
+geo_PqqD_fam	TIGR04302	GeoRSP system PqqD family protein
+GeoRSP_rSAM	TIGR04303	GeoRSP system radical SAM/SPASM protein
+GeoRSP_SPASM	TIGR04304	GeoRSP system SPASM domain protein
+fol_rel_CADD	TIGR04305	putative folate metabolism protein, CADD family
+salvage_TenA	TIGR04306	thiaminase II
+ProTailRpt	TIGR04307	proline-rich tail region repeat
+repeat_SSSPR51	TIGR04308	surface protein repeat SSSPR-51
+amanitin	TIGR04309	amanitin/phalloidin family toxin
+pantocin_A_pre	TIGR04310	pantocin A family RiPP
+rSAM_Geo_metal	TIGR04311	putative metalloenzyme radical SAM/SPASM domain maturase
+choice_anch_B	TIGR04312	choice-of-anchor B domain
+aro_clust_Mycop	TIGR04313	aromatic cluster surface protein
+methano7heme	TIGR04314	methanogenesis multiheme c-type cytochrome
+octaheme_Shew	TIGR04315	octaheme c-type cytochrome, tetrathionate reductase family
+dhbA_paeA	TIGR04316	2,3-dihydro-2,3-dihydroxybenzoate dehydrogenase
+W_rSAM_matur	TIGR04317	tungsten cofactor oxidoreducase radical SAM maturase
+lacto_ODC_hypo	TIGR04318	putative ornithine decarboxylase
+SerAla_Lrha_rpt	TIGR04319	surface protein repeat Ser-Ala-175
+Surf_Exclu_PgrA	TIGR04320	SEC10/PgrA surface exclusion domain
+spiroSPASM	TIGR04321	spiro-SPASM protein
+rSAM_QueE_Ecoli	TIGR04322	putative 7-cyano-7-deazaguanosine (preQ0) biosynthesis protein QueE
+SpoChoClust_1	TIGR04323	sporadic carbohydrate cluster protein, LIC12192 family
+SpoChoClust_2	TIGR04324	sporadic carbohydrate cluster 2OG-Fe(II) oxygenase
+MTase_LIC12133	TIGR04325	putative methyltransferase, LIC12133 family
+O_ant_LIC13510	TIGR04326	surface carbohydrate biosynthesis protein, LIC13510 family
+OMP_LA_2444	TIGR04327	outer membrane protein, LA_2444/LA_4059 family
+cas4_PREFRAN	TIGR04328	CRISPR-associated protein Cas4, subtype PREFRAN
+cas1_PREFRAN	TIGR04329	CRISPR-associated endonuclease Cas1, subtype PREFRAN
+cas_Cpf1	TIGR04330	CRISPR-associated protein Cpf1, subtype PREFRAN
+o_ant_LIC12162	TIGR04331	putative transferase, LIC12162 family
+gamma_Glu_sys	TIGR04332	poly-gamma-glutamate system protein
+Clo7Bot_mod_Cys	TIGR04333	Cys-rich peptide, Clo7bot family
+rSAM_Clo7bot	TIGR04334	radical SAM/SPASM domain Clo7bot peptide maturase
+AmmeMemoSam_A	TIGR04335	AmmeMemoRadiSam system protein A
+AmmeMemoSam_B	TIGR04336	AmmeMemoRadiSam system protein B
+AmmeMemoSam_rS	TIGR04337	AmmeMemoRadiSam system radical SAM enzyme
+HEXXH_Rv0185	TIGR04338	putative metallohydrolase, TIGR04338 family
+PQQ_MSMEG_3727	TIGR04339	PQQ system protein
+rSAM_ACGX	TIGR04340	radical SAM/SPASM domain protein, ACGX system
+target_ACGX	TIGR04341	ACGX-repeat peptide
+EXLDI	TIGR04342	EXLDI protein
+egtE_PLP_lyase	TIGR04343	ergothioneine biosynthesis PLP-dependent enzyme EgtE
+ovoA_Nterm	TIGR04344	5-histidylcysteine sulfoxide synthase
+ovoA_Cterm	TIGR04345	putative 4-mercaptohistidine N1-methyltranferase
+DotA_TraY	TIGR04346	conjugal transfer/type IV secretion protein DotA/TraY
+pseudo_SAM_Halo	TIGR04347	pseudo-rSAM protein/SPASM domain protein
+TIGR04348	TIGR04348	putative glycosyltransferase, TIGR04348 family
+rSAM_QueE_gams	TIGR04349	putative 7-cyano-7-deazaguanosine (preQ0) biosynthesis protein QueE
+C_S_lyase_PatB	TIGR04350	putative C-S lyase
+TOMM_nitrile_2	TIGR04351	putative TOMM peptide
+HprK_rel_A	TIGR04352	HprK-related kinase A
+PqqD_rel_X	TIGR04353	PqqD family protein, HPr-rel-A system
+amphi-Trp	TIGR04354	amphi-Trp domain
+HprK_rel_B	TIGR04355	HprK-related kinase B
+grasp_GAK	TIGR04356	ATP-grasp enzyme, GAK system
+CofD_rel_GAK	TIGR04357	CofD-related protein, GAK system
+XXXCH_domain	TIGR04358	XXXCH domain
+TrbK_RP4	TIGR04359	entry exclusion lipoprotein TrbK
+other_trbK	TIGR04360	conjugative transfer region protein TrbK
+TrbK_Ti	TIGR04361	entry exclusion protein TrbK
+choice_anch_C	TIGR04362	choice-of-anchor C domain
+LD_lanti_pre	TIGR04363	FxLD family lantipeptide
+methyltran_FxLD	TIGR04364	methyltransferase, FxLD system
+spare_glycyl	TIGR04365	autonomous glycyl radical cofactor GrcA
+cupin_WbuC	TIGR04366	cupin fold metalloprotein, WbuC family
+HpnR_B12_rSAM	TIGR04367	hopanoid C-3 methylase HpnR
+Glu_2_3_NH3_mut	TIGR04368	glutamate 2,3-aminomutase
+fusion_not_SelD	TIGR04369	oxidoreductase/SelD-related fusion protein
+glyco_rpt_poly	TIGR04370	oligosaccharide repeat unit polymerase
+methyltran_NanM	TIGR04371	putative sugar O-methyltransferase
+glycosyl_04372	TIGR04372	putative glycosyltransferase, TIGR04372 family
+egtB_X_signatur	TIGR04373	EgtB-related enzyme signature domain
+small_w_EgtBD	TIGR04374	hercynine metabolism small protein
+cyano_w_EgtBD	TIGR04375	hercynine metabolism protein
+TIGR04376	TIGR04376	TIGR04376 family protein
+myo_inos_iolD	TIGR04377	3,5/4-trihydroxycyclohexa-1,2-dione hydrolase
+myo_inos_iolB	TIGR04378	5-deoxy-glucuronate isomerase
+myo_inos_iolE	TIGR04379	myo-inosose-2 dehydratase
+myo_inos_iolG	TIGR04380	inositol 2-dehydrogenase
+HTH_TypR	TIGR04381	TyrR family helix-turn-helix domain
+myo_inos_iolC_N	TIGR04382	5-dehydro-2-deoxygluconokinase
+acidic_w_LPXTA	TIGR04383	processed acidic surface protein
+putr_carbamoyl	TIGR04384	putrescine carbamoyltransferase
+B12_rSAM_cofa1	TIGR04385	putative variant cofactor biosynthesis B12-binding domain/radical SAM domain protein 1
+ThiC_like_1	TIGR04386	ThiC-like protein 1
+capsid_maj_N4	TIGR04387	major capsid protein, N4-gp56 family
+Lepto_longest	TIGR04388	putative large structural protein
+Lepto_lipo_1	TIGR04389	lipoprotein, tandem type
+OMP_YaiO_dom	TIGR04390	outer membrane protein, YaiO family
+CcmD_alt_fam	TIGR04391	CcmD family protein
+haoB_nitrify	TIGR04392	hydroxylamine oxidation protein HaoB
+rpt_T5SS_PEPC	TIGR04393	T5SS/PEP-CTERM-associated repeat
+choline_CutC	TIGR04394	choline trimethylamine-lyase
+cutC_activ_rSAM	TIGR04395	choline TMA-lyase-activating enzyme
+surf_polysacc	TIGR04396	surface carbohydrate biosynthesis protein
+SecA2_Bac_anthr	TIGR04397	accessory Sec system translocase SecA2
+SLAP_DUP	TIGR04398	SLAP domain
+acc_Sec_SLAP	TIGR04399	accessory Sec system S-layer assembly protein
+RK_trnsloc_Pase	TIGR04400	Arg-Lys translocation region protein phosphatase
+TAT_Cys_rich	TIGR04401	twin-arginine translocation signal/Cys-rich four helix bundle protein
+mob_CxxC_CxxC	TIGR04402	mobilome CxxCx(11)CxxC protein
+rSAM_skfB	TIGR04403	sporulation killing factor system radical SAM maturase
+RiPP_SkfA	TIGR04404	sporulation killing factor
+SkfF	TIGR04405	sporulation killing factor system integral membrane protein
+LPS_export_lptB	TIGR04406	LPS export ABC transporter ATP-binding protein
+LptF_YjgP	TIGR04407	LPS export ABC transporter permease LptF
+LptG_lptG	TIGR04408	LPS export ABC transporter permease LptG
+LptC_YrbK	TIGR04409	LPS export ABC transporter periplasmic protein LptC
+Spiro_T2SS_lipo	TIGR04410	type II secretion system-associated lipoprotein
+T2SS_GspN_Lepto	TIGR04411	type II secretion system protein N
+T2SS_GspM_XcpZ	TIGR04412	type II secretion system protein M
+MYXAN_cmx8	TIGR04413	CRISPR type MYXAN-associated protein Cmx8
+hepto_Aah_TibC	TIGR04414	autotransporter strand-loop-strand O-heptosyltransferase
+O_hepto_targRPT	TIGR04415	autotransporter passenger strand-loop-strand repeat
+group_II_RT_mat	TIGR04416	group II intron reverse transcriptase/maturase
+PFTS_polysacc	TIGR04417	polysaccharide biosynthesis PFTS motif protein
+PriB_gamma	TIGR04418	primosomal replication protein PriB
+no_iron_rSAM	TIGR04419	HemN-related non-iron pseudo-SAM protein PsgB
+Sec_Non_Glob	TIGR04420	Sec region non-globular protein
+FemAB_IMCC1989	TIGR04421	FemAB family protein
+PLP_IMCC1989	TIGR04422	putative PLP-dependent aminotransferase
+casT3_TIGR04423	TIGR04423	CRISPR type III-associated protein, TIGR04423 family
+metallo_McbB	TIGR04424	McbB family protein
+P_lya_rel_AroB	TIGR04425	putative sugar phosphate phospholyase (cyclizing)
+rSAM_desII	TIGR04426	TDP-4-amino-4,6-dideoxy-D-glucose deaminase
+PLP_DesI	TIGR04427	dTDP-4-dehydro-6-deoxyglucose aminotransferase
+B12_rSAM_trp_MT	TIGR04428	tryptophan 2-C-methyltransferase
+Phr_nterm	TIGR04429	Phr family secreted Rap phosphatase inhibitor
+OM_asym_MlaD	TIGR04430	outer membrane lipid asymmetry maintenance protein MlaD
+N6_acetyl_AAC6	TIGR04431	aminoglycoside N(6')-acetyltransferase, AacA4 family
+rSAM_Cfr	TIGR04432	23S rRNA (adenine(2503)-C(8))-methyltransferase Cfr
+UrcA_uranyl	TIGR04433	UrcA family protein
+rSAM_Pput_1520	TIGR04434	B12-binding domain/radical SAM domain protein
+restrict_AAA_1	TIGR04435	restriction system-associated AAA family ATPase
+SpoChoClust_3	TIGR04436	putative 2OG-Fe(II) oxygenase
+WaaZ_KDO_III	TIGR04437	3-deoxy-D-manno-oct-2-ulosonate III transferase WaaZ
+small_Trp_rich	TIGR04438	small Trp-rich protein
+histamin_N_OH	TIGR04439	putative histamine N-monooxygenase
+glyco_TIGR04440	TIGR04440	glycosyltransferase domain
+lept_O_ant_chp1	TIGR04441	surface carbohydrate biosynthesis protein
+TIGR04442	TIGR04442	TIGR04442 family protein
+F420_CofF	TIGR04443	coenzyme gamma-F420-2:alpha-L-glutamate ligase
+chori_FkbO_Hyg5	TIGR04444	chorismatase, FkbO/Hyg5 family
+preny_LynF_TruF	TIGR04445	peptide O-prenyltransferase, LynF/TruF/PatF family
+pren_cyc_PirE	TIGR04446	prenylated cyclic peptide, anacyclamide/piricyclamide family
+PatC_TenC_TruC	TIGR04447	cyanobactin cluster PatC/TenC/TruC protein
+creatininase	TIGR04448	creatininase
+halocin_C8_dom	TIGR04449	halocin C8-like bacteriocin domain
+Gpos_C8_like	TIGR04450	putative immunity protein/bacteriocin
+lanti_SCO0268	TIGR04451	lantipeptide, SCO0268 family
+Lepto_Lipo_YY_C	TIGR04452	small lipoprotein, LA_3946 family
+Lepto_8Cys	TIGR04453	Cys-rich protein, LA_1312 family
+Lepto_4Cys	TIGR04454	small lipoprotein, LB_250 family
+lipo_MXAN_6521	TIGR04455	probable lipoprotein, LA_1396/MXAN_6521 family
+LruC_dom	TIGR04456	LruC domain
+lipo_LenA_lepto	TIGR04457	lipoprotein LenA
+CYP450_TxtE	TIGR04458	4-nitrotryptophan synthase
+TisB_tox	TIGR04459	type I toxin-antitoxin system toxin TisB
+endura_MppR	TIGR04460	enduracididine biosynthesis enzyme MppR
+endura_MppQ	TIGR04461	enduracididine biosynthesis enzyme MppQ
+endura_MppP	TIGR04462	enduracididine biosynthesis enzyme MppP
+rSAM_vs_C_rich	TIGR04463	radical SAM/SPASM domain protein maturase
+chaper_lep	TIGR04464	LipL41-expression chaperone Lep
+ArgArg_F420	TIGR04465	TAT-translocated F420-dependent dehydrogenase, FGD2 family
+rSAM_BlsE	TIGR04466	cytosylglucuronate decarboxylase
+CGA_synthase	TIGR04467	hydroxymethylcytosylglucuronate/cytosylglucuronate synthase
+arg_2_3_am_muta	TIGR04468	arginine 2,3-aminomutase
+CGA_synth_rel	TIGR04469	CGA synthase-related protein
+rSAM_mob_pairB	TIGR04470	radical SAM mobile pair protein B
+rSAM_mob_pairA	TIGR04471	radical SAM mobile pair protein A
+reg_rSAM_mob	TIGR04472	mobile rSAM pair MarR family regulator
+taxol_Phe_23mut	TIGR04473	phenylalanine aminomutase (L-beta-phenylalanine forming)
+tcm_partner	TIGR04474	three-Cys-motif partner protein
+Phe_D_beta_mut	TIGR04475	phenylalanine aminomutase (D-beta-phenylalanine forming)
+exosort_XrtN	TIGR04476	exosortase N
+sorted_by_XrtN	TIGR04477	XrtN system VIT domain protein
+rSAM_YfkAB	TIGR04478	radical SAM/CxCxxxxC motif protein YfkAB
+bcpD_PhpK_rSAM	TIGR04479	radical SAM P-methyltransferase, PhpK family
+D_pro_red_PrdA	TIGR04480	D-proline reductase (dithiol), PrdA proprotein
+PR_assoc_PrdC	TIGR04481	proline reductase-associated electron transfer protein PrdC
+D_pro_red_PrdD	TIGR04482	proline reductase cluster protein PrdD
+D_pro_red_PrdB	TIGR04483	D-proline reductase (dithiol), PrdB protein
+thiosulf_SoxA	TIGR04484	sulfur oxidation c-type cytochrome SoxA
+thiosulf_SoxX	TIGR04485	sulfur oxidation c-type cytochrome SoxX
+thiosulf_SoxB	TIGR04486	thiosulfohydrolase SoxB
+SoxY_para_1	TIGR04487	SoxY-related AACIE arm protein
+SoxY_true_GGCGG	TIGR04488	thiosulfate oxidation carrier protein SoxY
+exosort_XrtO	TIGR04489	exosortase O
+SoxZ_true	TIGR04490	thiosulfate oxidation carrier complex protein SoxZ
+reactive_PduG	TIGR04491	diol dehydratase reactivase alpha subunit
+VioB	TIGR04492	iminophenyl-pyruvate dimer synthase VioB
+microcomp_PduM	TIGR04493	microcompartment protein PduM
+c550_PedF	TIGR04494	cytochrome c-550 PedF
+RiPP_XyeA	TIGR04495	putative rSAM-modified RiPP, XyeA family
+rSAM_XyeB	TIGR04496	radical SAM/SPASM domain peptide maturase, XyeB family
+GRASP_targ_2	TIGR04497	putative ATP-grasp target RiPP
+AbiV_defense	TIGR04498	abortive infection protein, AbiV family
+abortive_AbiA	TIGR04499	abortive infection protein, AbiA family
+PpiC_rel_mature	TIGR04500	putative peptide maturation system protein
+microcomp_PduB	TIGR04501	microcompartment protein PduB
+microcomp_EutL	TIGR04502	microcompartment protein EutL
+mft_etfB	TIGR04503	electron transfer flavoprotein, mycofactocin-associated
+SDR_subfam_2	TIGR04504	SDR family mycofactocin-dependent oxidoreductase
+PtsS_plasma	TIGR04505	phosphate ABC transporter substrate-binding protein
+F_threo_transal	TIGR04506	fluorothreonine transaldolase
+fluorinase	TIGR04507	adenosyl-fluoride synthase
+queE_Cx14CxxC	TIGR04508	7-carboxy-7-deazaguanine synthase
+mod_pep_NH_fam	TIGR04509	putative modified peptide
+mod_pep_cyc	TIGR04510	putative peptide modification system cyclase
+SagB_rel_DH_2	TIGR04511	putative peptide maturation dehydrogenase
+Mycopla_NOT_gsn	TIGR04512	STREFT protein
+VPAMP_CTERM	TIGR04513	VPAMP-CTERM protein sorting domain
+GWxTD_dom	TIGR04514	GWxTD domain
+P450_rel_GT_act	TIGR04515	P450-derived glycosyltranferase activator
+glycosyl_450act	TIGR04516	glycosyltransferase, activator-dependent family
+rSAM_PoyD	TIGR04517	radical SAM family RiPP maturation amino acid epimerase
+ECF_S_folT_fam	TIGR04518	ECF transporter S component, folate family
+MoCo_extend_TAT	TIGR04519	MoCo/4Fe-4S cofactor protein extended Tat translocation domain
+ECF_ATPase_1	TIGR04520	energy-coupling factor transporter ATPase
+ECF_ATPase_2	TIGR04521	energy-coupling factor transporter ATPase
+EcfS_MSC_0063	TIGR04522	putative energy coupling factor transporter S component
+Mplasa_alph_rch	TIGR04523	helix-rich protein
+mycoplas_M_dom	TIGR04524	IgG-blocking virulence domain
+prot_M_MG281	TIGR04525	IgG-blocking protein M
+predic_Ig_block	TIGR04526	putative immunoglobulin-blocking virulence protein
+mycoplas_twoTM	TIGR04527	two transmembrane protein
+acido_non_PQQ	TIGR04528	acido-empty-quinoprotein group A
+MTB_hemophore	TIGR04529	hemophore-related protein, Rv0203/Rv1174c family
+hemophoreRv0203	TIGR04530	hemophore
+nonproteo_OH	TIGR04531	putative nonproteinogenic amino acid hydroxylase
+PT_fungal_PKS	TIGR04532	polyketide product template domain
+cyanosortB_assc	TIGR04533	cyanoexosortase B-associated protein
+ELWxxDGT_rpt	TIGR04534	ELWxxDGT repeat
+ferrit_encaps	TIGR04535	ferritin-like protein
+geobac_encap	TIGR04536	encapsulated protein
+encap_target	TIGR04537	encapsulation C-terminal sorting signal
+P450_cycloAA_1	TIGR04538	cytochrome P450, cyclodipeptide synthase-associated
+tRNA_cyclodipep	TIGR04539	tRNA-dependent cyclodipeptide synthase
+CLB_0814_fam	TIGR04540	conserved hypothetical protein
+thiaminase_BcmE	TIGR04541	thiamine pyridinylase
+GMC_mycofac_2	TIGR04542	GMC family mycofactocin-associated oxidreductase
+ketoArg_3Met	TIGR04543	2-ketoarginine methyltransferase
+3metArgNH2trans	TIGR04544	beta-methylarginine biosynthesis bifunctional aminotransferase
+rSAM_ahbD_hemeb	TIGR04545	heme b synthase
+rSAM_ahbC_deAc	TIGR04546	12,18-didecarboxysiroheme deacetylase
+Mollicu_LP	TIGR04547	MOLPALP family lipoprotein
+DnaD_Mollicutes	TIGR04548	DnaD family protein
+LP_HExxH_w_tonB	TIGR04549	substrate import-associated zinc metallohydrolase lipoprotein
+sMetMonox_MmoD	TIGR04550	soluble methane monooxygenase-binding protein MmoD
+TIGR04551	TIGR04551	TIGR04551 family protein
+TIGR04552	TIGR04552	TIGR04552 family protein
+ABC_peri_selen	TIGR04553	putative selenate ABC transporter periplasmic binding protein
+3TM_mycoplas	TIGR04554	three transmembrane helix protein
+sulfite_DH_soxC	TIGR04555	sulfite dehydrogenase
+PKS_assoc	TIGR04556	polyketide synthase-associated domain
+fuse_rel_SoxYZ	TIGR04557	quinoprotein dehydrogenase-associated SoxYZ-like carrier
+SoxH_rel_PQQ_1	TIGR04558	quinoprotein relay system zinc metallohydrolase 1
+SoxH_rel_PQQ_2	TIGR04559	quinoprotein relay system zinc metallohydrolase 2
+ribo_THX	TIGR04560	ribosomal small subunit protein bTHX
+membra_charge	TIGR04561	integral membrane protein
+TIGR04562	TIGR04562	TIGR04562 family protein
+TIGR04563	TIGR04563	MXAN_4361/MXAN_4362 family small protein
+Synergist_CTERM	TIGR04564	Synergist-CTERM protein sorting domain
+OMP_myx_plus	TIGR04565	outer membrane beta-barrel protein
+myxo_TraA_Nterm	TIGR04566	outer membrane exchange protein TraA, N-terminal region
+RNAP_delt_lowGC	TIGR04567	DNA-directed RNA polymerase delta subunit
+arch_SelU_Nterm	TIGR04568	selenouridine synthase, SelU N-terminal-like subunit
+arch_SelU_Cterm	TIGR04569	selenouridine synthase, SelU C-terminal-like subunit
+mollicut_2TM	TIGR04570	small integral membrane protein
+LmtA_Leptospira	TIGR04571	lipid A Kdo2 1-phosphate O-methyltransferase

--- a/docs/purity_tutorial.md
+++ b/docs/purity_tutorial.md
@@ -1,0 +1,102 @@
+# Testing the functional purity of reference packages
+
+This documentation covers the subcommand `treesapp purity`, used for determining the orthologous groups, genes, acivities etc.
+ present in a reference package (RefPkg) by assigning sequences from a specially-formatted FASTA file.
+
+This is an important step when annotating genomes and metagenomes using a gene-centric approach where the breadth of
+reference sequences just isn't as comprehensive as public biological sequence repositories such as RefSeq.
+When using a single RefPkg, the major hazard is annotating marginally homologous sequences
+ because the more similar sequences are absent from the reference set.
+This problem may be mitigated by using multiple RefPkgs that cover this sequence space or using a RefPkg that includes all homologs.
+An example of the latter approach is the RefPkg DsrAB where we include both the oxidative and reductive forms of DsrA and DsrB
+ (paralogs themselves) as well as a clade each of AsrC, nitrite and sulphite reductases and other COG2221-related.
+
+Moreover, `treesapp purity` is a further validation step in cases where the repositories
+ used to gather your candidate reference sequences were questionably curated.
+This method can report homologs that you may not have been aware of and highlights instances where
+ the HMM used is not as specific as we'd like*. 
+
+## Ingredients
+
+As mentioned, a specially-formatted FASTA file is required to perform the most basic purity-analysis.
+In this FASTA, the functional information for each group must be the prefix of every header
+ and the unique sequence identifiers can follow.
+Here is an example snippet where sequences belong to the families TIGR00001, TIGR00014 and TIGR04570:
+```
+>TIGR00001_SP|P94976|RL35_MYCTU/2-64
+PKAKTHSGASKRFRRTGT.GKIVRQKANRRHLLEHKPSTRT.RRLDGRTVVAANDTKRVT.SLLNG
+>TIGR00014_GP|12544000|emb|CAC26382.1/3-114
+VTIFHNPRCSTSRNTLAYLRDKDIEPEIVQYLKDTPTASELKELFNTLGIPV.HDGIRTREAEYTELGLS.PETPETELIDAIVAHPRLLQRPIVVTAKGARIARPKIDVIDSI
+>TIGR04570_GB|CAE77370|MYCMY/1-87
+MNEFNLAKDKTMISKIFKKIPWFYHLIFFLIGLVVGLLFQFLRVKTFAFPYFFILFFAVLLTYCVLFIIISPMIKQNWFIKRVKNEK
+```
+
+Users are able to use `TreeSAPP/dev_utils/TIGRFAM_seed_named.faa` that includes all the TIGRFAM seed sequences.
+This file was created by concatenating all [TIGRFAM protein sequence files](ftp://ftp.jcvi.org/pub/data/TIGRFAMs/)
+ together while prepending headers with their respective TIGRFAM identifier, separated with an underscore.
+Additionally a tabular file with 3 columns, like that of `TreeSAPP/dev_utils/TIGRFAM_info.tsv`,
+ can be used to provide the detailed functional information.
+This was created using an ugly bash one-liner from the TIGRFAM INFO files.
+ 
+We are not tied to either of these formats so if you have strong feelings to improve these,
+ let us know on the issues page!
+We are thinking of ways to make it easier for folks to create their own FASTAs of characterized sequences.
+ 
+Crucially, though, these sequences _must be trustworthy_.
+This analysis is only as good as the inputs, so if the reference sequences' activities haven't been characterized there
+is no point in using them.
+This is why we are only using the seed sequences where these sequence annotations are definitely correct. 
+
+## Usage
+
+Use `treesapp purity -h` to print the usage and command-line arguments available to you. 
+
+In this example we will evaluate the purity of the RefPkg for the alpha subunit of methyl-coenzyme M reductase (McrA).
+Since we have provided the characterized sequences and information table in `TreeSAPP/dev_utils`
+ it is very easy to run after installing TreeSAPP.
+The following command is ran from the TreeSAPP directory after cloning from GitHub and installing. 
+
+```bash
+treesapp purity -i dev_utils/TIGRFAM_seed_named.faa -x dev_utils/TIGRFAM_info.tsv \
+-r McrA -o McrA_purity -p treesapp/data/ -m prot -n 2
+```
+
+`-p treesapp/data/` specifies the path to the RefPkg, indicating that this RefPkg was created and
+ individual HMM, alignment, tree and lineage information files were copied to their respective directories
+  (details can be found in the [treesapp create tutorial](https://github.com/hallamlab/TreeSAPP/blob/master/docs/Marker_package_creation_tutorial.md)).
+
+## Output
+
+The output should be:
+```
+Summarizing assignments for reference package McrA
+Ortholog	Hits	Leaves	Tree-coverage	Description
+--------------------------------------------------------------------------------
+TIGR03256	4	4	1.8	methyl-coenzyme M reductase, alpha subunit
+```
+
+The _hits_ column is the number of characterized query sequences that were mapped to the tree and classified by `treesapp assign`.
+The _leaves_ column is the number of reference sequences that were transitively assigned as that OG
+ (by being a descendent of the node in the RefPkg's tree where an input sequence was placed).
+This assignment is similar to how TreeSAPP assigns taxonomy to query sequences.
+
+Also, all reference sequences in the RefPkg that were classified are listed in the log file (e.g. McrA_purity/TreeSAPP_purity_log.txt ),
+ under the ortholog group (OG; first column in the above table) they were assigned. For example:
+
+```
+TIGR03256:
+        Methanosarcina barkeri | CAA68357
+        Methanothermus fervidus DSM 2088 | ADP77583
+        Methanothermobacter thermautotrophicus | CAA30639
+        Methanopyrus kandleri AV19 | AAM01870
+``` 
+
+These results indicate that the McrA RefPkg is pure. Also, since _hits_ is equal to _leaves_ and the _Tree-coverage_
+ is low these characterized query sequences are very similar to the RefPkg references.
+
+## Notes
+
+\* This can be improved where reference sequences contain domains that are not tightly coupled to
+ the activity (or activities) desired from sequences in the RefPkg.
+Just trim that stuff off and rerun `treesapp create`! Unfortunately much of this is manual.
+Feel free to contact us for help by email!

--- a/treesapp/__main__.py
+++ b/treesapp/__main__.py
@@ -5,14 +5,15 @@ import sys
 import argparse
 import logging
 
-from .commands import (create, evaluate, assign, update, info, train, layer)
+from .commands import (create, evaluate, assign, update, info, train, layer, purity)
 # from .clade_exclusion_evaluator import main as evaluate_main
 
 usage = """
 treesapp <command> [<args>]
 ** Commands include:
 create         Create a reference package for a new gene, domain or orthologous group
-evaluate       Evaluate the classification performance using Clade-exclusion analysis
+evaluate       Evaluate the classification performance using clade exclusion analysis
+purity         Characterize the sequences in a reference package using a curated database
 assign         Classify query [protein|genomic] sequences using reference packages
 layer          Layer extra annotation information on classifications with iTOL colours-style file(s)  
 update         Update an existing reference package with sequences found in a `classify` run
@@ -30,7 +31,8 @@ def main():
                 "update": update,
                 "info": info,
                 "train": train,
-                "layer": layer}
+                "layer": layer,
+                "purity": purity}
     parser = argparse.ArgumentParser(description='Phylogenetic classification of biological sequences')
     parser.add_argument('command', nargs='?')
     args = parser.parse_args(sys.argv[1:2])

--- a/treesapp/classy.py
+++ b/treesapp/classy.py
@@ -1251,6 +1251,8 @@ class TreeSAPP:
                 self.acc_to_lin = self.var_output_dir + os.sep + "accession_id_lineage_map.tsv"
         elif self.command == "update":
             self.acc_to_lin = self.var_output_dir + os.sep + "accession_id_lineage_map.tsv"
+        elif self.command == "purity":
+            pass
         else:
             logging.error("Unknown sub-command: " + str(self.command) + "\n")
             sys.exit(3)
@@ -1495,6 +1497,32 @@ class Creator(TreeSAPP):
                      "4. $ cp " + self.ref_pkg.profile + ' ' + self.hmm_dir + "\n" +
                      "5. $ cp " + self.ref_pkg.msa + ' ' + self.aln_dir + "\n")
         return
+
+
+class Purity(TreeSAPP):
+    def __init__(self):
+        super(Purity, self).__init__("purity")
+        self.assign_dir = ""
+        self.classifications = ""
+        self.summarize_dir = ""
+        self.assignments = None
+        self.refpkg_build = MarkerBuild()
+        self.stages = {0: ModuleFunction("assign", 0),
+                       1: ModuleFunction("summarize", 1)}
+
+    def identify_groups_assigned(self):
+        unique_orthologs = dict()
+        for refpkg, info in self.assignments.items():
+            for lineage in info:
+                for seq_name in info[lineage]:
+                    bits_pieces = seq_name.split('_')
+                    if bits_pieces[0] not in unique_orthologs:
+                        unique_orthologs[bits_pieces[0]] = []
+                    unique_orthologs[bits_pieces[0]].append('_'.join(bits_pieces[1:]))
+
+        logging.info("Ortholog\tHits\n" + "-"*20 + "\n" +
+                     "\n".join([k + "\t" + str(len(v)) for k, v in unique_orthologs.items()]) + "\n")
+        return unique_orthologs
 
 
 class Evaluator(TreeSAPP):

--- a/treesapp/file_parsers.py
+++ b/treesapp/file_parsers.py
@@ -13,7 +13,7 @@ from .fasta import read_fasta_to_dict
 __author__ = 'Connor Morgan-Lang'
 
 
-def parse_ref_build_params(base_dir: str, targets: list):
+def parse_ref_build_params(base_dir: str, targets=None):
     """
     Returns a dictionary of MarkerBuild objects storing information pertaining to the build parameters of each marker.
     :param base_dir: Path to the treesapp package directory containing 'data/ref_build_parameters.tsv'

--- a/treesapp/treesapp_args.py
+++ b/treesapp/treesapp_args.py
@@ -4,7 +4,7 @@ import sys
 import re
 import logging
 from glob import glob
-from .classy import Assigner, Evaluator, Creator, PhyTrainer, Updater
+from .classy import Assigner, Evaluator, Creator, PhyTrainer, Updater, Purity
 from .utilities import available_cpu_count, get_refpkg_build
 from .entrez_utils import read_accession_taxa_map
 
@@ -239,6 +239,22 @@ def add_create_arguments(parser: TreeSAPPArgumentParser):
                                    help="Do not require any user input during runtime.")
 
 
+def add_purity_arguments(parser: TreeSAPPArgumentParser):
+    parser.add_io()
+    parser.add_seq_params()
+    parser.add_compute_miscellany()
+    parser.reqs.add_argument("-r", "--reference_marker", dest="refpkg", required=True,
+                             help="Short-form name of the marker gene to be tested (e.g. mcrA, pmoA, nosZ)")
+    parser.reqs.add_argument("-p", "--pkg_path", dest="pkg_path", required=True,
+                             help="Path to the reference package.\n")
+    parser.optopt.add_argument("-x", "--extra_info", required=False, default=None,
+                               help="File mapping header prefixes to description information.")
+    parser.optopt.add_argument("--stage", default="continue", required=False,
+                               choices=["continue", "lineages", "classify", "calculate"],
+                               help="The stage(s) for TreeSAPP to execute [DEFAULT = continue]")
+    return
+
+
 def add_evaluate_arguments(parser: TreeSAPPArgumentParser):
     parser.add_io()
     parser.add_seq_params()
@@ -309,7 +325,7 @@ def add_trainer_arguments(parser: TreeSAPPArgumentParser):
                              help="Unique name to be used by TreeSAPP internally. NOTE: Must be <=6 characters.\n"
                                   "Examples are 'McrA', 'DsrAB', and 'p_amoA'.")
     parser.reqs.add_argument("-p", "--pkg_path", required=True,
-                             help="Path to the reference package.\n",)
+                             help="Path to the reference package.\n")
     parser.seqops.add_argument("-d", "--profile", required=False, default=False, action="store_true",
                                help="Flag indicating input sequences need to be purified using an HMM profile.")
     parser.optopt.add_argument("--stage", default="continue", required=False,
@@ -350,6 +366,27 @@ def check_parser_arguments(args, sys_args):
         logging.warning("Number of threads specified is greater than those available! "
                         "Using maximum threads available (" + str(available_cpu_count()) + ")\n")
         args.num_threads = available_cpu_count()
+
+    return
+
+
+def check_purity_arguments(purity_instance: Purity, args, marker_build_dict: dict):
+    purity_instance.ref_pkg.prefix = args.refpkg
+    purity_instance.refpkg_build = get_refpkg_build(purity_instance.ref_pkg.prefix,
+                                                    marker_build_dict,
+                                                    purity_instance.refpkg_code_re)
+    purity_instance.pkg_path = args.pkg_path
+    purity_instance.ref_pkg.gather_package_files(purity_instance.pkg_path, purity_instance.molecule_type)
+
+    ##
+    # Define locations of files TreeSAPP outputs
+    ##
+    purity_instance.assign_dir = purity_instance.var_output_dir + "assign" + os.sep
+    purity_instance.summarize_dir = purity_instance.var_output_dir + "summarize" + os.sep
+    purity_instance.classifications = purity_instance.assign_dir + "final_outputs" + os.sep + "marker_contig_map.tsv"
+
+    if not os.path.isdir(purity_instance.var_output_dir):
+        os.makedirs(purity_instance.var_output_dir)
 
     return
 

--- a/treesapp/treesapp_args.py
+++ b/treesapp/treesapp_args.py
@@ -252,6 +252,7 @@ def add_purity_arguments(parser: TreeSAPPArgumentParser):
     parser.optopt.add_argument("--stage", default="continue", required=False,
                                choices=["continue", "lineages", "classify", "calculate"],
                                help="The stage(s) for TreeSAPP to execute [DEFAULT = continue]")
+    # TODO: Remove --trim_align from command-line options in parser.add_seq_params()
     return
 
 
@@ -384,6 +385,7 @@ def check_purity_arguments(purity_instance: Purity, args, marker_build_dict: dic
     purity_instance.assign_dir = purity_instance.var_output_dir + "assign" + os.sep
     purity_instance.summarize_dir = purity_instance.var_output_dir + "summarize" + os.sep
     purity_instance.classifications = purity_instance.assign_dir + "final_outputs" + os.sep + "marker_contig_map.tsv"
+    purity_instance.metadata_file = args.extra_info
 
     if not os.path.isdir(purity_instance.var_output_dir):
         os.makedirs(purity_instance.var_output_dir)


### PR DESCRIPTION
This branch includes the subcommand `treesapp purity` for determining the orthologous groups, genes, acivities etc. when assigning sequences from a specially-formatted database. The functional information for each group must prefix the unique sequence identifiers in a FASTA.

Users are able to use the file `dev_utils/TIGRFAM_seed_named.faa` including all the TIGRFAM seed sequences. Additionally a tabular file with 3 columns, like that of `dev_utils/TIGRFAM_info.tsv`, can be used to provide the detailed functional information.

Example command is 
```
treesapp purity -i dev_utils/TIGRFAM_seed_named.faa -r McrA -p treesapp/data/ -o McrA_purity -m prot -x dev_utils/TIGRFAM_info.tsv -n 2
```