### PR TITLE
Replace USEARCH with VSEARCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,34 +48,41 @@ before_install:
         conda install -y -c etetoolkit ete3;
       fi
     - if [ "$TRAVIS_OS_NAME" != "osx" ]; then
-        sudo apt -y install gcc dpkg-dev curl zip git libz-dev default-jdk time time libssl-dev libsqlite3-dev \
+        sudo apt -y install gcc dpkg-dev zip git libz-dev default-jdk time time libssl-dev libsqlite3-dev \
           autotools-dev libtool flex bison cmake automake autoconf \
           python3-distutils python3-dev;
         sudo apt install python-six -y;
 
         wget https://mafft.cbrc.jp/alignment/software/mafft_7.450-1_amd64.deb;
         sudo dpkg -i mafft_7.450-1_amd64.deb;
-        sudo curl -LJ0 --output /usr/local/bin/BMGE.jar https://github.com/hallamlab/TreeSAPP/raw/master/treesapp/sub_binaries/BMGE.jar;
-        curl -LJ0 --output hmmer-${HMMER_VERSION}.tar.gz http://eddylab.org/software/hmmer/hmmer-${HMMER_VERSION}.tar.gz;
+
+        wget https://github.com/hallamlab/TreeSAPP/raw/master/treesapp/sub_binaries/BMGE.jar;
+        sudo mv BMGE.jar /usr/local/bin/;
+
+        wget -O hmmer-${HMMER_VERSION}.tar.gz http://eddylab.org/software/hmmer/hmmer-${HMMER_VERSION}.tar.gz;
         tar -xzf hmmer-${HMMER_VERSION}.tar.gz; cd hmmer-${HMMER_VERSION}/; ./configure; make -f Makefile;
         sudo cp src/hmmsearch src/hmmbuild src/hmmalign /usr/bin/;
         cd -; rm hmmer-${HMMER_VERSION}.tar.gz;
-        curl -LJ0 --output /usr/local/bin/prodigal https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux && \
-        chmod +x /usr/local/bin/prodigal
-      	curl -LJ0 --output od-seq.tar.gz http://www.bioinf.ucd.ie/download/od-seq.tar.gz; tar -xzf od-seq.tar.gz;
-      	ODSEQ_SOURCES="OD-Seq/AliReader.cpp OD-Seq/Bootstrap.cpp OD-Seq/DistCalc.cpp OD-Seq/DistMatReader.cpp \
-      	OD-Seq/DistWriter.cpp OD-Seq/FastaWriter.cpp OD-Seq/IQR.cpp OD-Seq/ODseq.cpp OD-Seq/PairwiseAl.cpp \
+
+        wget -O prodigal https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux;
+        sudo mv prodigal /usr/local/bin/ && chmod +x /usr/local/bin/prodigal;
+
+      	wget -O od-seq.tar.gz http://www.bioinf.ucd.ie/download/od-seq.tar.gz; tar -xzf od-seq.tar.gz;
+      	ODSEQ_SOURCES="OD-Seq/AliReader.cpp OD-Seq/Bootstrap.cpp OD-Seq/DistCalc.cpp OD-Seq/DistMatReader.cpp
+      	OD-Seq/DistWriter.cpp OD-Seq/FastaWriter.cpp OD-Seq/IQR.cpp OD-Seq/ODseq.cpp OD-Seq/PairwiseAl.cpp
       	OD-Seq/Protein.cpp OD-Seq/ResultWriter.cpp OD-Seq/runtimeargs.cpp OD-Seq/util.cpp";
       	sudo g++ -fopenmp -o /usr/bin/OD-seq $ODSEQ_SOURCES;
       	rm od-seq.tar.gz;
-        sudo curl -LJ0 --output /usr/local/bin/FastTree http://microbesonline.org/fasttree/FastTreeDbl;
+
+        sudo wget -O /usr/local/bin/FastTree http://microbesonline.org/fasttree/FastTreeDbl;
         sudo chmod +x /usr/local/bin/FastTree;
-        curl -LJ0 --output raxml-ng_v${RAXML_VERSION}.zip \
-        https://github.com/amkozlov/raxml-ng/releases/download/${RAXML_VERSION}/raxml-ng_v${RAXML_VERSION}_linux_x86_64.zip;
+
+        wget -O raxml-ng_v${RAXML_VERSION}.zip https://github.com/amkozlov/raxml-ng/releases/download/${RAXML_VERSION}/raxml-ng_v${RAXML_VERSION}_linux_x86_64.zip;
         mkdir raxml-ng_v${RAXML_VERSION}; unzip raxml-ng_v${RAXML_VERSION}.zip -d raxml-ng_v${RAXML_VERSION};
         sudo cp raxml-ng_v${RAXML_VERSION}/raxml-ng /usr/local/bin/;
         rm -r raxml-ng_v${RAXML_VERSION}.zip raxml-ng_v${RAXML_VERSION};
-        curl -LJ0 --output epa-ng.tar.gz https://github.com/Pbdas/epa-ng/archive/v${EPA_VERSION}.tar.gz;
+
+        wget -O epa-ng.tar.gz https://github.com/Pbdas/epa-ng/archive/v${EPA_VERSION}.tar.gz;
         tar -xzf epa-ng.tar.gz; cd epa-ng-${EPA_VERSION}/;
         make; sudo cp bin/epa-ng /usr/local/bin/; cd -;
         rm epa-ng.tar.gz;

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,39 +47,31 @@ before_install:
         conda install -y -c etetoolkit ete3;
       fi
     - if [ "$TRAVIS_OS_NAME" != "osx" ]; then
-        # Install the linux package dependencies
         sudo apt -y install gcc dpkg-dev curl zip git libz-dev default-jdk time time libssl-dev libsqlite3-dev \
           autotools-dev libtool flex bison cmake automake autoconf \
           python3-distutils python3-dev;
         sudo apt install python-six -y;
 
-        # Install MAFFT
         wget https://mafft.cbrc.jp/alignment/software/mafft_7.450-1_amd64.deb;
         sudo dpkg -i mafft_7.450-1_amd64.deb;
-        # Install BMGE
         sudo curl -LJ0 --output /usr/local/bin/BMGE.jar https://github.com/hallamlab/TreeSAPP/raw/master/treesapp/sub_binaries/BMGE.jar;
-        # Install HMMER
         curl -LJ0 --output hmmer-${HMMER_VERSION}.tar.gz http://eddylab.org/software/hmmer/hmmer-${HMMER_VERSION}.tar.gz;
         tar -xzf hmmer-${HMMER_VERSION}.tar.gz; cd hmmer-${HMMER_VERSION}/; ./configure; make -f Makefile;
         sudo cp src/hmmsearch src/hmmbuild src/hmmalign /usr/bin/;
         cd -; rm hmmer-${HMMER_VERSION}.tar.gz;
-        # Install OD-Seq
       	curl -LJ0 --output od-seq.tar.gz http://www.bioinf.ucd.ie/download/od-seq.tar.gz; tar -xzf od-seq.tar.gz;
       	ODSEQ_SOURCES="OD-Seq/AliReader.cpp OD-Seq/Bootstrap.cpp OD-Seq/DistCalc.cpp OD-Seq/DistMatReader.cpp \
       	OD-Seq/DistWriter.cpp OD-Seq/FastaWriter.cpp OD-Seq/IQR.cpp OD-Seq/ODseq.cpp OD-Seq/PairwiseAl.cpp \
       	OD-Seq/Protein.cpp OD-Seq/ResultWriter.cpp OD-Seq/runtimeargs.cpp OD-Seq/util.cpp";
       	sudo g++ -fopenmp -o /usr/bin/OD-seq $ODSEQ_SOURCES;
       	rm od-seq.tar.gz;
-        # Install FastTree
         sudo curl -LJ0 --output /usr/local/bin/FastTree http://microbesonline.org/fasttree/FastTreeDbl;
         sudo chmod +x /usr/local/bin/FastTree;
-        # Install RAxML-NG
         curl -LJ0 --output raxml-ng_v${RAXML_VERSION}.zip \
         https://github.com/amkozlov/raxml-ng/releases/download/${RAXML_VERSION}/raxml-ng_v${RAXML_VERSION}_linux_x86_64.zip;
         mkdir raxml-ng_v${RAXML_VERSION}; unzip raxml-ng_v${RAXML_VERSION}.zip -d raxml-ng_v${RAXML_VERSION};
         sudo cp raxml-ng_v${RAXML_VERSION}/raxml-ng /usr/local/bin/;
         rm -r raxml-ng_v${RAXML_VERSION}.zip raxml-ng_v${RAXML_VERSION};
-        # Install EPA-NG
         curl -LJ0 --output epa-ng.tar.gz https://github.com/Pbdas/epa-ng/archive/v${EPA_VERSION}.tar.gz;
         tar -xzf epa-ng.tar.gz; cd epa-ng-${EPA_VERSION}/;
         make; sudo cp bin/epa-ng /usr/local/bin/; cd -;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
       - EPA_VERSION="0.3.8"
       - BWA_VERSION="0.7.17"
       - HMMER_VERSION="3.3"
+      - PRODIGAL_VERSION="2.6.3"
 
 jobs:
     include:
@@ -59,6 +60,8 @@ before_install:
         tar -xzf hmmer-${HMMER_VERSION}.tar.gz; cd hmmer-${HMMER_VERSION}/; ./configure; make -f Makefile;
         sudo cp src/hmmsearch src/hmmbuild src/hmmalign /usr/bin/;
         cd -; rm hmmer-${HMMER_VERSION}.tar.gz;
+        curl -LJ0 --output /usr/local/bin/prodigal https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux && \
+        chmod +x /usr/local/bin/prodigal
       	curl -LJ0 --output od-seq.tar.gz http://www.bioinf.ucd.ie/download/od-seq.tar.gz; tar -xzf od-seq.tar.gz;
       	ODSEQ_SOURCES="OD-Seq/AliReader.cpp OD-Seq/Bootstrap.cpp OD-Seq/DistCalc.cpp OD-Seq/DistMatReader.cpp \
       	OD-Seq/DistWriter.cpp OD-Seq/FastaWriter.cpp OD-Seq/IQR.cpp OD-Seq/ODseq.cpp OD-Seq/PairwiseAl.cpp \

--- a/dev_utils/Dockerfile
+++ b/dev_utils/Dockerfile
@@ -6,7 +6,8 @@ ENV TREESAPP_VERSION="0.9.1"\
   PRODIGAL_VERSION="2.6.3"\
   HMMER_VERSION="3.3"\
   RAXML_VERSION="1.0.1"\
-  EPA_VERSION="0.3.8"
+  EPA_VERSION="0.3.8"\
+  VSEARCH_VERSION="2.15.0"
 
 LABEL base.image="ubuntu:bionic"
 LABEL container.version="0.1"
@@ -50,6 +51,11 @@ RUN curl -LJ0 --output /usr/local/bin/BMGE.jar https://github.com/hallamlab/Tree
 RUN curl -LJ0 --output mafft.deb https://mafft.cbrc.jp/alignment/software/mafft_${MAFFT_VERSION}_amd64.deb && \
  dpkg -i mafft.deb && \
  rm mafft.deb
+
+RUN wget https://github.com/torognes/vsearch/archive/v${VSEARCH_VERSION}.tar.gz && \
+ tar xzf v${VSEARCH_VERSION}.tar.gz && \
+ cd vsearch-${VSEARCH_VERSION} && \
+ ./autogen.sh && ./configure && make && make install
 
 RUN curl -LJ0 --output /usr/bin/prodigal https://github.com/hyattpd/Prodigal/releases/download/v${PRODIGAL_VERSION}/prodigal.linux && \
  chmod +x /usr/bin/prodigal

--- a/dev_utils/TreeSAPP.def
+++ b/dev_utils/TreeSAPP.def
@@ -2,9 +2,6 @@ BootStrap: library
 From: ubuntu:18.04
 Stage: build
 
-%files
-    /usr/local/bin/usearch
-
 %post
     export TS_VERSION="0.9.1"
     export RAXML_VERSION="1.0.1"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CLASSIFIERS = [
 SETUP_METADATA = \
     {
         "name": "treesapp",
-        "version": "0.9.1",
+        "version": "0.9.2",
         "description": "TreeSAPP is a functional and taxonomic annotation tool for genomes and metagenomes.",
         "long_description": LONG_DESCRIPTION,
         "long_description_content_type": "text/markdown",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,7 +103,7 @@ class TreesappTester(unittest.TestCase):
         test_refpkg.f__json = "./TreeSAPP_create/final_outputs/Crt_build.pkl"
         test_refpkg.slurp()
         test_refpkg.validate()
-        self.assertEqual(69, test_refpkg.num_seqs)
+        self.assertEqual(70, test_refpkg.num_seqs)
         self.assertEqual(2, len(test_refpkg.pfit))
         self.assertTrue(test_refpkg.pfit[0] < 0)
         return
@@ -155,7 +155,7 @@ class TreesappTester(unittest.TestCase):
         test_refpkg.f__json = "./TreeSAPP_create/final_outputs/PF01280_build.pkl"
         test_refpkg.slurp()
         test_refpkg.validate()
-        self.assertEqual(52, test_refpkg.num_seqs)
+        self.assertEqual(54, test_refpkg.num_seqs)
         return
 
     def test_evaluate(self):
@@ -249,7 +249,7 @@ class TreesappTester(unittest.TestCase):
         test_refpkg.f__json = "./TreeSAPP_update/final_outputs/PuhA_build.pkl"
         test_refpkg.slurp()
         test_refpkg.validate()
-        self.assertEqual(49, test_refpkg.num_seqs)
+        self.assertEqual(50, test_refpkg.num_seqs)
         return
 
     def test_update_seqs2lineage(self):
@@ -271,7 +271,7 @@ class TreesappTester(unittest.TestCase):
         test_refpkg.f__json = "./TreeSAPP_update/final_outputs/PuhA_build.pkl"
         test_refpkg.slurp()
         test_refpkg.validate()
-        self.assertEqual(49, test_refpkg.num_seqs)
+        self.assertEqual(50, test_refpkg.num_seqs)
         return
 
     def test_train(self):

--- a/treesapp/__init__.py
+++ b/treesapp/__init__.py
@@ -1,4 +1,4 @@
 #! /usr/bin/env python
 
 name = "treesapp"
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/treesapp/classy.py
+++ b/treesapp/classy.py
@@ -567,7 +567,7 @@ class TreeSAPP:
             dependencies += ["bwa"]
 
         if self.command in ["create", "update", "train", "evaluate"]:
-            dependencies += ["usearch", "mafft"]
+            dependencies += ["vsearch", "mafft"]
             if hasattr(args, "fast") and args.fast:
                 dependencies.append("FastTree")
 

--- a/treesapp/commands.py
+++ b/treesapp/commands.py
@@ -485,7 +485,7 @@ def create(sys_args):
     fasta.write_new_fasta(fasta_dict=ref_seqs.fasta_dict, fasta_name=ref_seqs.file, headers=filtered_headers)
 
     ##
-    # Optionally cluster the input sequences using USEARCH at the specified identity
+    # Optionally cluster the input sequences using VSEARCH at the specified identity
     ##
     if ts_create.stage_status("cluster"):
         ref_seqs.change_dict_keys("num")
@@ -495,7 +495,7 @@ def create(sys_args):
                               fasta_name=ts_create.cluster_input,
                               headers=list(fasta_records.keys()))
         if args.cluster:
-            wrapper.cluster_sequences(ts_create.executables["usearch"], ts_create.cluster_input,
+            wrapper.cluster_sequences(ts_create.executables["vsearch"], ts_create.cluster_input,
                                       ts_create.uclust_prefix, ts_create.ref_pkg.pid)
             ts_create.uc = ts_create.uclust_prefix + ".uc"
         # Read the uc file if present
@@ -847,7 +847,7 @@ def update(sys_args):
         # not all clustering tools + versions keep whole header - spaces are replaced with underscores
         fasta.write_new_fasta(fasta_dict=combined_fasta.fasta_dict,
                               fasta_name=ts_updater.cluster_input)
-        wrapper.cluster_sequences(ts_updater.executables["usearch"], ts_updater.cluster_input,
+        wrapper.cluster_sequences(ts_updater.executables["vsearch"], ts_updater.cluster_input,
                                   ts_updater.uclust_prefix, ts_updater.prop_sim)
         ts_updater.uc = ts_updater.uclust_prefix + ".uc"
 

--- a/treesapp/create_refpkg.py
+++ b/treesapp/create_refpkg.py
@@ -135,7 +135,7 @@ def create_new_ref_fasta(out_fasta, ref_seq_dict, dashes=False):
 def regenerate_cluster_rep_swaps(args, cluster_dict, fasta_replace_dict):
     """
     Function to regenerate the swappers dictionary with the original headers as keys and
-    the new header (swapped in the previous attempt based on USEARCH's uc file) as a value
+    the new header (swapped in the previous attempt based on VSEARCH's uc file) as a value
 
     :param args: command-line arguments objects
     :param cluster_dict: Dictionary where keys are centroid headers and values are headers of identical sequences
@@ -636,7 +636,7 @@ def guarantee_ref_seqs(cluster_dict: dict, important_seqs: set) -> dict:
 def cluster_lca(cluster_dict: dict, fasta_record_objects: dict, header_registry: dict) -> None:
     """
     Populates the cluster_lca attribute for Cluster instances by calculating the lowest common ancestor (LCA)
-    across all lineages of sequences in a cluster (inferred using a sequence clustering tool such as USEARCH)
+    across all lineages of sequences in a cluster (inferred using a sequence clustering tool such as VSEARCH)
 
     :param cluster_dict: A dictionary of Cluster instanced indexed by their numerical cluster IDs
     :param fasta_record_objects: A dictionary of EntrezRecord instances indexed by TreeSAPP numerical IDs

--- a/treesapp/file_parsers.py
+++ b/treesapp/file_parsers.py
@@ -573,9 +573,9 @@ def read_stockholm_to_dict(sto_file):
 
 def read_uc(uc_file):
     """
-    Function to read a USEARCH cluster (.uc) file
+    Function to read a VSEARCH cluster (.uc) file
 
-    :param uc_file: Path to a .uc file produced by USEARCH
+    :param uc_file: Path to a .uc file produced by VSEARCH
     :return: Dictionary where keys are numerical identifiers and values are Cluster objects
         The Cluster object
     """
@@ -584,10 +584,10 @@ def read_uc(uc_file):
     try:
         uc = open(uc_file, 'r')
     except IOError:
-        logging.error("Unable to open USEARCH cluster file " + uc_file + " for reading!\n")
+        logging.error("Unable to open VSEARCH cluster file " + uc_file + " for reading!\n")
         sys.exit(13)
 
-    logging.debug("Reading usearch cluster file... ")
+    logging.debug("Reading VSEARCH cluster file... ")
 
     # Find all clusters with multiple identical sequences
     for line in uc:

--- a/treesapp/placement_trainer.py
+++ b/treesapp/placement_trainer.py
@@ -294,7 +294,7 @@ def prepare_training_data(test_seqs: fasta.FASTA, output_dir: str, executables: 
 
     test_seqs.change_dict_keys("num")
     fasta.write_new_fasta(test_seqs.fasta_dict, uclust_input)
-    wrapper.cluster_sequences(executables["usearch"], uclust_input, uclust_prefix, similarity)
+    wrapper.cluster_sequences(executables["vsearch"], uclust_input, uclust_prefix, similarity)
     cluster_dict = file_parsers.read_uc(uclust_prefix + ".uc")
     test_seqs.keep_only([cluster_dict[clust_id].representative for clust_id in cluster_dict.keys()])
     logging.debug("\t" + str(len(test_seqs.fasta_dict.keys())) + " sequence clusters\n")

--- a/treesapp/treesapp_args.py
+++ b/treesapp/treesapp_args.py
@@ -665,14 +665,14 @@ def check_create_arguments(creator: Creator, args) -> None:
         if not 0.5 <= float(args.similarity) <= 1.0:
             if 0.5 < float(args.similarity)/100 < 1.0:
                 args.similarity = str(float(args.similarity)/100)
-                logging.warning("--similarity  set to {} for compatibility with USEARCH.\n".format(args.similarity))
+                logging.warning("--similarity  set to {} for compatibility with VSEARCH.\n".format(args.similarity))
             else:
                 logging.error("--similarity {} is not between the supported range [0.5-1.0].\n".format(args.similarity))
                 sys.exit(13)
 
     if args.taxa_lca and not args.cluster:
         logging.error("Unable to perform LCA for representatives without clustering information: " +
-                      "either with a provided UCLUST file or by clustering within the pipeline.\n")
+                      "either with a provided VSEARCH file or by clustering within the pipeline.\n")
         sys.exit(13)
 
     if args.guarantee and not args.cluster:
@@ -729,7 +729,7 @@ def check_updater_arguments(updater: Updater, args):
         if not 0.5 <= float(args.similarity) <= 1.0:
             if 0.5 < float(args.similarity) / 100 < 1.0:
                 args.similarity = str(float(args.similarity) / 100)
-                logging.warning("--similarity  set to {} for compatibility with USEARCH.\n".format(args.similarity))
+                logging.warning("--similarity  set to {} for compatibility with VSEARCH.\n".format(args.similarity))
             else:
                 logging.error("--similarity {} is not between the supported range [0.5-1.0].\n".format(args.similarity))
                 sys.exit(13)

--- a/treesapp/utilities.py
+++ b/treesapp/utilities.py
@@ -263,7 +263,7 @@ def executable_dependency_versions(exe_dict: dict) -> str:
 
     simple_v = ["prodigal", "raxmlHPC", "epa-ng"]
     version_param = ["trimal", "mafft", "raxml-ng"]
-    no_params = ["usearch", "papara"]
+    no_params = ["vsearch", "papara"]
     help_param = ["hmmbuild", "hmmalign", "hmmsearch", "OD-seq"]
     version_re = re.compile(r"[Vv]\d+.\d|version \d+.\d|\d\.\d\.\d|HMMER")
 

--- a/treesapp/wrapper.py
+++ b/treesapp/wrapper.py
@@ -401,60 +401,27 @@ def run_papara(executable, tree_file, ref_alignment_phy, query_fasta, molecule):
     return stdout
 
 
-def cluster_new_reference_sequences(update_tree, args, new_ref_seqs_fasta):
-    logging.info("Clustering sequences at %s percent identity with USEARCH... " % str(update_tree.cluster_id))
-
-    usearch_command = [args.executables["usearch"]]
-    usearch_command += ["-sortbylength", new_ref_seqs_fasta]
-    usearch_command += ["-fastaout", update_tree.Output + "usearch_sorted.fasta"]
-    usearch_command += ["--log", update_tree.Output + os.sep + "usearch_sort.log"]
-    # usearch_command += ["1>", "/dev/null", "2>", "/dev/null"]
-
-    launch_write_command(usearch_command)
-
-    uclust_id = "0." + str(int(update_tree.cluster_id))
-    try:
-        float(uclust_id)
-    except ValueError:
-        logging.error("Weird formatting of cluster_id: " + uclust_id + "\n")
-
-    uclust_command = [args.executables["usearch"]]
-    uclust_command += ["-cluster_fast", update_tree.Output + "usearch_sorted.fasta"]
-    uclust_command += ["--id", uclust_id]
-    uclust_command += ["--centroids", update_tree.Output + "uclust_" + update_tree.COG + ".fasta"]
-    uclust_command += ["--uc", update_tree.Output + "uclust_" + update_tree.COG + ".uc"]
-    uclust_command += ["--log", update_tree.Output + os.sep + "usearch_cluster.log"]
-    # uclust_command += ["1>", "/dev/null", "2>", "/dev/null"]
-
-    launch_write_command(uclust_command)
-
-    logging.info("done.\n")
-
-    return
-
-
 def cluster_sequences(uclust_exe, fasta_input, uclust_prefix, similarity=0.60):
     """
-    Wrapper function for clustering a FASTA file at some similarity using usearch's cluster_fast algorithm
+    Wrapper function for clustering a FASTA file at some similarity using vsearch's cluster_fast algorithm
 
-    :param uclust_exe: Path to the usearch executable
+    :param uclust_exe: Path to the vsearch executable
     :param fasta_input: FASTA file for which contained sequences will be clustered
     :param uclust_prefix: Prefix for the output files
     :param similarity: The proportional similarity to cluster input sequences
     :return: None
     """
-    logging.info("Clustering sequences with UCLUST... ")
+    logging.info("Clustering sequences with VSEARCH's cluster_fast algorithm... ")
     uclust_cmd = [uclust_exe]
-    uclust_cmd += ["-cluster_fast", fasta_input]
-    uclust_cmd += ["-id", str(similarity)]
-    uclust_cmd += ["-sort", "length"]
-    uclust_cmd += ["-centroids", uclust_prefix + ".fa"]
+    uclust_cmd += ["--cluster_fast", fasta_input]
+    uclust_cmd += ["--id", str(similarity)]
+    uclust_cmd += ["--centroids", uclust_prefix + ".fa"]
     uclust_cmd += ["--uc", uclust_prefix + ".uc"]
     logging.info("done.\n")
     stdout, returncode = launch_write_command(uclust_cmd)
 
     if returncode != 0:
-        logging.error("UCLUST did not complete successfully! Command used:\n" +
+        logging.error("VSEARCH did not complete successfully! Command used:\n" +
                       ' '.join(uclust_cmd) + "\n")
         sys.exit(13)
 


### PR DESCRIPTION
USEARCH is very difficult to include in containers as there isn't a public-facing download link for the binaries or source code. This also makes it difficult to design integrative tests that will succeed on continuous integration servers, as USEARCH cannot be installed.

Switching to VSEARCH, the open-source alternative, seemed like the obvious choice. Tests have been updated and very little needed to be changed.