### PR TITLE
Taxa selection

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 class TreesappTester(unittest.TestCase):
     def setUp(self) -> None:
         from .testing_utils import get_test_data
+        self.num_procs = 4
         # FASTA files
         self.aa_test_fa = get_test_data("marker_test_suite.faa")
         self.nt_test_fa = get_test_data("marker_test_suite.fna")
@@ -37,7 +38,7 @@ class TreesappTester(unittest.TestCase):
         assign_commands_list = ["--fastx_input", self.aa_test_fa,
                                 "--targets", ','.join(ref_pkgs),
                                 "--refpkg_dir", self.refpkg_dir,
-                                "--num_procs", str(2),
+                                "--num_procs", str(self.num_procs),
                                 "-m", "prot",
                                 "--output", "./TreeSAPP_assign/",
                                 "--stringency", "relaxed",
@@ -54,7 +55,7 @@ class TreesappTester(unittest.TestCase):
         from treesapp.file_parsers import read_classification_table
         assign_commands_list = ["--fastx_input", self.nt_test_fa,
                                 "--targets", ','.join(ref_pkgs),
-                                "--num_procs", str(2),
+                                "--num_procs", str(self.num_procs),
                                 "-m", "dna",
                                 "--output", "./TreeSAPP_assign/",
                                 "--stringency", "strict",
@@ -97,7 +98,7 @@ class TreesappTester(unittest.TestCase):
                                 "--screen", "Bacteria", "--filter", "Archaea",
                                 "--min_taxonomic_rank", 'p',
                                 "--output", "./TreeSAPP_create",
-                                "--num_proc", str(2),
+                                "--num_procs", str(self.num_procs),
                                 "--trim_align", "--cluster", "--fast", "--headless", "--overwrite", "--delete"]
         create(create_commands_list)
         test_refpkg = ReferencePackage()
@@ -120,7 +121,7 @@ class TreesappTester(unittest.TestCase):
                                 "--profile", get_test_data("PuhA_search.hmm"),
                                 "--molecule", "prot",
                                 "--screen", "Bacteria,Archaea",
-                                "--num_proc", str(4),
+                                "--num_procs", str(self.num_procs),
                                 "--raxml_model", "LG+F+R4",
                                 "--min_taxonomic_rank", 'p',
                                 "--stage", "support",
@@ -148,7 +149,7 @@ class TreesappTester(unittest.TestCase):
                     "--molecule", "prot",
                     "--screen", "Archaea", "--filter", "Bacteria,Eukaryota",
                     "--min_taxonomic_rank", 'g',
-                    "--num_proc", str(2),
+                    "--num_procs", str(self.num_procs),
                     "--stage", "evaluate",
                     "--trim_align", "--cluster", "--fast", "--headless", "--overwrite", "--delete"]
         create(cmd_list)
@@ -168,7 +169,7 @@ class TreesappTester(unittest.TestCase):
                                  "-o", "./TreeSAPP_evaluate",
                                  "-m", "prot",
                                  "--taxonomic_ranks", "class", "order",
-                                 "-n", str(2),
+                                 "-n", str(self.num_procs),
                                  "--trim_align", "--overwrite", "--delete"]
         evaluate(evaluate_command_list)
         self.assertEqual(True, True)
@@ -184,7 +185,7 @@ class TreesappTester(unittest.TestCase):
                                   "--reads", get_test_data("test_TarA.1.fq"),
                                   "--reverse", get_test_data("test_TarA.2.fq"),
                                   "--pairing", "pe",
-                                  "--num_procs", str(2),
+                                  "--num_procs", str(self.num_procs),
                                   "--delete"]
         abundance(abundance_command_list)
         post_lines = read_classification_table(get_test_data(classification_table))
@@ -198,7 +199,8 @@ class TreesappTester(unittest.TestCase):
                                "--extra_info", get_treesapp_file("dev_utils/TIGRFAM_info.tsv"),
                                "--output", "./TreeSAPP_purity",
                                "--refpkg_path", self.mcra_pkl,
-                               "--trim_align", "--molecule", "prot", "-n", str(2)]
+                               "-num_procs", str(self.num_procs),
+                               "--trim_align", "--molecule", "prot"]
         purity(purity_command_list)
         self.assertEqual(True, True)
         return
@@ -241,7 +243,7 @@ class TreesappTester(unittest.TestCase):
                                "--refpkg_path", self.puha_pkl,
                                "--treesapp_output", get_test_data("assign_SwissProt_PuhA/"),
                                "--output", "./TreeSAPP_update",
-                               "--num_proc", str(4),
+                               "--num_proc", str(self.num_procs),
                                "--molecule", "prot",
                                "--trim_align", "--cluster", "--fast", "--headless",
                                "--overwrite", "--delete", "--skip_assign", "--resolve"]
@@ -262,7 +264,7 @@ class TreesappTester(unittest.TestCase):
                                "--treesapp_output", get_test_data("assign_SwissProt_PuhA/"),
                                "--seqs2lineage", get_test_data("SwissProt_PuhA_seqs2lineage.txt"),
                                "--output", "./TreeSAPP_update",
-                               "--num_proc", str(2),
+                               "--num_procs", str(self.num_procs),
                                "--molecule", "prot",
                                "-b", str(0),
                                "--trim_align", "--cluster", "--fast", "--headless",
@@ -287,7 +289,7 @@ class TreesappTester(unittest.TestCase):
                               "--refpkg_path", self.puha_pkl,
                               "--accession2lin", get_test_data("ENOG4111FIN_accession_id_lineage_map.tsv"),
                               "--max_examples", str(max_ex),
-                              "--num_proc", str(4),
+                              "--num_proc", str(self.num_procs),
                               "--molecule", "prot",
                               "--svm_kernel", "rbf",
                               "--classifier", "bin",
@@ -332,7 +334,7 @@ class TreesappTester(unittest.TestCase):
                "--targets", "McrA",
                "--molecule", "prot",
                "--tool", "treesapp",
-               "--num_procs", str(4),
+               "--num_procs", str(self.num_procs),
                "--delete", "--svm", "--overwrite"]
         MCC_calculator.mcc_calculator(cmd)
         self.assertEqual(True, True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -91,6 +91,7 @@ class TreesappTester(unittest.TestCase):
         from .testing_utils import get_test_data
         create_commands_list = ["--fastx_input", get_test_data("create_test.faa"),
                                 "--accession2taxid", get_test_data("create_test.accession2taxid"),
+                                "--seqs2lineage", get_test_data("create_test_accession2lin.tsv"),
                                 "--refpkg_name", "Crt",
                                 "--similarity", "0.95",
                                 "--bootstraps", str(0),
@@ -199,7 +200,7 @@ class TreesappTester(unittest.TestCase):
                                "--extra_info", get_treesapp_file("dev_utils/TIGRFAM_info.tsv"),
                                "--output", "./TreeSAPP_purity",
                                "--refpkg_path", self.mcra_pkl,
-                               "-num_procs", str(self.num_procs),
+                               "--num_procs", str(self.num_procs),
                                "--trim_align", "--molecule", "prot"]
         purity(purity_command_list)
         self.assertEqual(True, True)

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -72,8 +72,14 @@ class MyTestCase(unittest.TestCase):
 
     def test_read_fasta_to_dict(self):
         from treesapp.fasta import read_fasta_to_dict
+
+        # Test normal functionality with a fasta file
         fa_dict = read_fasta_to_dict(self.test_fa)
         self.assertEqual(236, len(fa_dict))
+
+        # Test reading a file that doesn't exist
+        self.assertEqual({}, read_fasta_to_dict("./fake_file.fa"))
+        return
 
     def test_split_fa_size(self):
         from treesapp.fasta import split_fa, read_fasta_to_dict

--- a/tests/test_refpkg.py
+++ b/tests/test_refpkg.py
@@ -47,15 +47,20 @@ class RefPkgTester(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.disband_path, "McrA.fa")))
 
     def test_remove_taxon_from_lineage_ids(self):
+        # Ensure the initial state is as expected
+        self.assertEqual(246, self.db.num_seqs)
+        self.assertEqual(246, len(self.db.lineage_ids))
+
+        # Test
         self.db.remove_taxon_from_lineage_ids("d__Archaea; p__Euryarchaeota; c__Methanobacteria; o__Methanobacteriales;"
                                               " f__Methanobacteriaceae; g__Methanosphaera")
-        self.assertEqual(190, self.db.num_seqs)
+        self.assertEqual(193, self.db.num_seqs)
         self.db.remove_taxon_from_lineage_ids("d__Archaea; p__Euryarchaeota; c__Methanobacteria")
-        self.assertEqual(143, len(self.db.lineage_ids))
+        self.assertEqual(146, len(self.db.lineage_ids))
 
         self.db.remove_taxon_from_lineage_ids("d__Archaea")
-        self.assertEqual(0, len(self.db.lineage_ids))
-        self.assertEqual(0, self.db.num_seqs)
+        self.assertEqual(3, len(self.db.lineage_ids))
+        self.assertEqual(3, self.db.num_seqs)
 
     def test_get_fasta(self):
         refpkg_fa = self.db.get_fasta()

--- a/tests/test_taxonomic_hierarchy.py
+++ b/tests/test_taxonomic_hierarchy.py
@@ -86,9 +86,8 @@ class TaxonomicHierarchyTester(unittest.TestCase):
                       {'ScientificName': 'Prochlorococcus', 'Rank': 'genus'}])
         self.assertEqual("r__Root; d__Bacteria; p__Cyanobacteria",
                          self.db.check_lineage(lineage=t4_lineage, organism=t4_organism))
-        return
 
-    def test_check_lineage_nonexistant(self):
+        # Test a lineage that doesn't exist in the hierarchy
         with pytest.raises(RuntimeError):
             self.db.check_lineage(lineage="d__Archaea", organism="Archaea")
         return

--- a/tests/test_taxonomic_hierarchy.py
+++ b/tests/test_taxonomic_hierarchy.py
@@ -55,6 +55,64 @@ class TaxonomicHierarchyTester(unittest.TestCase):
     def test_fixture(self):
         self.assertEqual(True, hasattr(self, "db"))
 
+    def test_check_lineage(self):
+        t1_lineage = "n__cellular organisms; d__Bacteria; n__Terrabacteria group; p__Actinobacteria; c__Actinobacteria"
+        t1_organism = "Actinobacteria"
+        t2_lineage = "d__Bacteria; p__Actinobacteria; c__Actinobacteria; " \
+                     "o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces"
+        t2_organism = "s__Actinomyces nasicola"
+        t3_lineage = "r__Root; d__Bacteria; p__Actinobacteria; c__Actinobacteria; o__Actinomycetales"
+        t4_lineage = "d__Bacteria; p__Cyanobacteria; o__Synechococcales; f__Prochloraceae; g__Prochlorococcus"
+        t4_organism = "s__Prochlorococcus marinus"
+
+        # Remove the taxa that have no taxonomic rank
+        self.assertEqual(4,
+                         len(self.db.check_lineage(lineage=t1_lineage, organism=t1_organism,
+                                                   verbosity=1).split(self.db.lin_sep)))
+        # Add the organism as the new species
+        self.assertEqual(8,
+                         len(self.db.check_lineage(lineage=t2_lineage, organism=t2_organism,
+                                                   verbosity=1).split(self.db.lin_sep)))
+        # Nothing to change
+        self.assertEqual(t3_lineage,
+                         self.db.check_lineage(lineage=t3_lineage, organism=t3_lineage.split(self.db.lin_sep)[-1],
+                                               verbosity=1))
+        # Test when a taxon is out of order
+        self.db.feed("Bacteria; Cyanobacteria; Synechococcales; Prochloraceae; Prochlorococcus",
+                     [{'ScientificName': 'Bacteria', 'Rank': 'domain'},
+                      {'ScientificName': 'Cyanobacteria', 'Rank': 'phylum'},
+                      {'ScientificName': 'Synechococcales', 'Rank': 'order'},
+                      {'ScientificName': 'Prochloraceae', 'Rank': 'family'},
+                      {'ScientificName': 'Prochlorococcus', 'Rank': 'genus'}])
+        self.assertEqual("r__Root; d__Bacteria; p__Cyanobacteria",
+                         self.db.check_lineage(lineage=t4_lineage, organism=t4_organism))
+        return
+
+    def test_check_lineage_nonexistant(self):
+        with pytest.raises(RuntimeError):
+            self.db.check_lineage(lineage="d__Archaea", organism="Archaea")
+        return
+
+    def test_clean_lineage_string(self):
+        l1 = "n__cellular organisms; d__Bacteria; n__Terrabacteria group"
+        l2 = "d__Bacteria"
+        l3 = "d__Bacteria; p__Candidatus Omnitrophica; s__Candidatus Omnitrophica bacterium CG02__42_8"
+        self.assertEqual(self.db.clean_lineage_string(l1, with_prefix=True),
+                         self.db.clean_lineage_string(l2, with_prefix=True))
+        self.assertEqual("Bacteria", self.db.clean_lineage_string(l1, with_prefix=False))
+        self.assertEqual("d__Bacteria; p__Candidatus Omnitrophica; s__Candidatus Omnitrophica bacterium CG02_42_8",
+                         self.db.clean_lineage_string(l3, with_prefix=True))
+        return
+
+    def test_emit(self):
+        actino_line = "Root; Bacteria; Terrabacteria group; Actinobacteria;" \
+                      " Actinobacteria; Actinomycetales; Actinomycetaceae; Actinomyces"
+        bifido_line = "r__Root; d__Bacteria; n__Terrabacteria group; p__Actinobacteria;" \
+                      " c__Actinobacteria; o__Bifidobacteriales; f__Bifidobacteriaceae; g__Bifidobacterium"
+        self.assertEqual(actino_line, self.db.emit("g__Actinomyces"))
+        self.assertEqual(bifido_line, self.db.emit("g__Bifidobacterium", with_prefix=True))
+        return
+
     def test_feed(self):
         """
         Since lineages are already fed into self.db (via TaxonomicHierarchy.feed()), other functions are used for
@@ -78,57 +136,6 @@ class TaxonomicHierarchyTester(unittest.TestCase):
         self.assertTrue("n__environmental samples_1" in test_th.hierarchy)
         self.assertTrue("n__environmental samples_2" not in test_th.hierarchy)
         self.assertEqual(0, len(test_th.conflicts))
-        return
-
-    def test_emit(self):
-        actino_line = "Bacteria; Terrabacteria group; Actinobacteria;" \
-                      " Actinobacteria; Actinomycetales; Actinomycetaceae; Actinomyces"
-        bifido_line = "Bacteria; Terrabacteria group; Actinobacteria;" \
-                      " Actinobacteria; Bifidobacteriales; Bifidobacteriaceae; Bifidobacterium"
-        self.assertEqual(actino_line, self.db.emit("g__Actinomyces"))
-        self.assertEqual(bifido_line, self.db.emit("g__Bifidobacterium"))
-        return
-
-    def test_check_lineage(self):
-        t1_lineage = "n__cellular organisms; d__Bacteria; n__Terrabacteria group; p__Actinobacteria; c__Actinobacteria"
-        t1_organism = "Actinobacteria"
-        t2_lineage = "d__Bacteria; p__Actinobacteria; c__Actinobacteria; " \
-                     "o__Actinomycetales; f__Actinomycetaceae; g__Actinomyces"
-        t2_organism = "s__Actinomyces nasicola"
-        self.assertEqual(3,
-                         len(self.db.check_lineage(lineage=t1_lineage,
-                                                   organism=t1_organism).split(self.db.lin_sep)))
-        self.assertEqual(7,
-                         len(self.db.check_lineage(lineage=t2_lineage,
-                                                   organism=t2_organism).split(self.db.lin_sep)))
-        return
-
-    def test_check_lineage_nonexistant(self):
-        with pytest.raises(RuntimeError):
-            self.db.check_lineage(lineage="d__Archaea", organism="Archaea")
-        return
-
-    def test_check_lineage_rankless(self):
-        lin = "d__Bacteria; p__Cyanobacteria; o__Synechococcales; f__Prochloraceae; g__Prochlorococcus"
-        org = "s__Prochlorococcus marinus"
-        self.db.feed("Bacteria; Cyanobacteria; Synechococcales; Prochloraceae; Prochlorococcus",
-                     [{'ScientificName': 'Bacteria', 'Rank': 'domain'},
-                      {'ScientificName': 'Cyanobacteria', 'Rank': 'phylum'},
-                      {'ScientificName': 'Synechococcales', 'Rank': 'order'},
-                      {'ScientificName': 'Prochloraceae', 'Rank': 'family'},
-                      {'ScientificName': 'Prochlorococcus', 'Rank': 'genus'}])
-        self.assertEqual("d__Bacteria; p__Cyanobacteria", self.db.check_lineage(lineage=lin, organism=org))
-        return
-
-    def test_clean_lineage_string(self):
-        l1 = "n__cellular organisms; d__Bacteria; n__Terrabacteria group"
-        l2 = "d__Bacteria"
-        l3 = "d__Bacteria; p__Candidatus Omnitrophica; s__Candidatus Omnitrophica bacterium CG02__42_8"
-        self.assertEqual(self.db.clean_lineage_string(l1, with_prefix=True),
-                         self.db.clean_lineage_string(l2, with_prefix=True))
-        self.assertEqual("Bacteria", self.db.clean_lineage_string(l1, with_prefix=False))
-        self.assertEqual("d__Bacteria; p__Candidatus Omnitrophica; s__Candidatus Omnitrophica bacterium CG02_42_8",
-                         self.db.clean_lineage_string(l3, with_prefix=True))
         return
 
     def test_remove_leaf_nodes(self):
@@ -165,18 +172,67 @@ class TaxonomicHierarchyTester(unittest.TestCase):
         self.db.build_multifurcating_trie(key_prefix=False, value_prefix=True)
         self.assertTrue("Bacteria" in self.db.trie)
         self.assertEqual("c__Actinobacteria", self.db.trie["Bacteria; Actinobacteria; Actinobacteria"])
+        return
 
-    def test_rm_bad_taxa(self):
+    def test_rm_bad_taxa_from_lineage(self):
         self.assertEqual(["Archaea"], self.db.rm_bad_taxa_from_lineage(["cellular organisms", "Archaea"]))
+        return
+
+    def test_rm_absent_taxa_from_lineage(self):
+        ll_1 = ["d__Bacteria", "n__Absent", "p__Actinobacteria"]
+        ll_2 = ["Bacteria", "Actinomyces", "Actinobacteria"]
+        ll_3 = "d__Bacteria; p__Actinobacteria; c__Actinobacteria".split(self.db.lin_sep)
+        # Test a lineage containing a taxon that is not present in the taxonomic hierarchy
+        self.db.rm_absent_taxa_from_lineage(ll_1, True)
+        self.assertEqual(2, len(ll_1))
+        # Test a lineage where the taxa are out of order
+        self.db.rm_absent_taxa_from_lineage(ll_2)
+        self.assertEqual(3, len(ll_2))
+        # Test a lineage where all taxa are in the hierarchy -> lineage should be unchanged
+        self.db.rm_absent_taxa_from_lineage(ll_3, True)
+        self.assertEqual(3, len(ll_3))
+        return
 
     def test_get_prefixed_lineage_from_bare(self):
         self.db.clean_trie = True
         self.db.build_multifurcating_trie(key_prefix=False, value_prefix=True)
-        self.assertEqual("d__Bacteria",
+        # Determine whether a prefix for the root taxon is needed for the expected values
+        if self.db.rooted:
+            root_name = self.db.root_taxon + self.db.lin_sep
+        else:
+            root_name = ""
+        # Test a lineage with taxa with no rank
+        self.assertEqual(root_name + "d__Bacteria",
                          self.db.get_prefixed_lineage_from_bare("cellular organisms; Bacteria; "
                                                                 "Terrabacteria group; Actinobacteria"))
-        self.assertEqual("d__Bacteria; p__Actinobacteria; c__Actinobacteria",
+        # Test a lineage where two ranks share the same name
+        self.assertEqual(root_name + "d__Bacteria; p__Actinobacteria; c__Actinobacteria",
                          self.db.get_prefixed_lineage_from_bare("Bacteria; Actinobacteria; Actinobacteria"))
+        # Test a lineage that isn't found in the taxonomic hierarchy
+        with pytest.raises(SystemExit):
+            self.db.get_prefixed_lineage_from_bare("Archaea; Lokiarchaeota")
+        return
+
+    def test_get_bare_taxon(self):
+        with pytest.raises(RuntimeError):
+            self.db.get_bare_taxon("d__Bacteria")
+        with pytest.raises(SystemExit):
+            self.db.get_bare_taxon("E. coli")
+        taxon = self.db.get_bare_taxon("Actinobacteria")
+        self.assertIsNone(taxon)
+        taxon = self.db.get_bare_taxon("Bacteria")
+        self.assertEqual("d__Bacteria", taxon.prefix_taxon())
+        return
+
+    def test_reroot_lineage(self):
+        # Test without rank-prefixes on the taxa - should exit
+        with pytest.raises(RuntimeError):
+            self.db.reroot_lineage("Bacteria; Actinobacteria; Actinobacteria")
+        # Test with normal behaviour - adds the root taxon
+        self.assertEqual("r__Root; d__Bacteria", self.db.reroot_lineage("d__Bacteria"))
+        # Test when the lineage is already rooted - nothing should be changed
+        self.assertEqual("r__Root; d__Bacteria", self.db.reroot_lineage("r__Root; d__Bacteria"))
+        return
 
     def test_build_multifurcating_trie(self):
         self.db.trie_key_prefix = True
@@ -202,27 +258,36 @@ class TaxonomicHierarchyTester(unittest.TestCase):
 
     def test_root_domains(self):
         from treesapp.taxonomic_hierarchy import Taxon
-        with pytest.raises(AttributeError):
+        with pytest.raises(TypeError):
             self.db.root_domains("Root")
         root_taxon = Taxon(name="Root", rank="root")
-        self.db.root_domains(root_taxon)
+        root_taxon = self.db.root_domains(root_taxon)
         self.assertEqual(root_taxon, self.db.hierarchy["d__Bacteria"].parent)
         # Remove the Taxon 'r__Root' so other tests are not affected
         self.db.redirect_hierarchy_paths(root_taxon)
         return
 
     def test_match_organism(self):
+        # Prepare the lineages for testing, depending on whether the domains are rooted or not
+        ll_1 = ["d__Bacteria"]
+        ll_2 = ["d__Eukaryota"]
+        ll_3 = "d__Bacteria; p__Actinobacteria; c__Actinobacteria".split('; ')
+        if self.db.rooted:
+            ll_1 = [self.db.root_taxon] + ll_1
+            ll_2 = [self.db.root_taxon] + ll_2
+            ll_3 = [self.db.root_taxon] + ll_3
+
         # Test when organism isn't in the taxonomic hierarchy
         organism = self.db.match_organism(organism="doesn't exist",
-                                          lineage=["d__Bacteria"])
+                                          lineage=ll_1)
         self.assertEqual("", organism)
         # Test when the lineage isn't in the taxonomic hierarchy
         with pytest.raises(SystemExit):
-            self.db.match_organism(organism="Homo sapiens", lineage=["d__Eukaryota"])
+            self.db.match_organism(organism="Homo sapiens", lineage=ll_2)
 
         # Test when the organism isn't a descendent of the lineage
         organism = self.db.match_organism(organism="Methanosarcina barkeri",
-                                          lineage="d__Bacteria; p__Actinobacteria; c__Actinobacteria".split('; '))
+                                          lineage=ll_3)
         self.assertEqual("", organism)
         # Test when the lineage is the wrong type (string)
         with pytest.raises(TypeError):
@@ -230,7 +295,7 @@ class TaxonomicHierarchyTester(unittest.TestCase):
 
         # Behaviour when inputs are correct
         organism = self.db.match_organism(organism="Bifidobacterium",
-                                          lineage="d__Bacteria; p__Actinobacteria; c__Actinobacteria".split('; '))
+                                          lineage=ll_3)
         self.assertEqual("g__Bifidobacterium", organism)
         return
 

--- a/treesapp/assign.py
+++ b/treesapp/assign.py
@@ -448,21 +448,21 @@ def multiple_alignments(executables: dict, single_query_sequence_files: list,
     return concatenated_msa_files
 
 
-def create_ref_phy_files(refpkg_dict, output_dir, single_query_fasta_files, ref_aln_dimensions):
+def create_ref_phy_files(refpkgs: dict, output_dir: str, query_fasta_files: list, ref_aln_dimensions: dict) -> None:
     """
     Creates a phy file for every reference marker that was matched by a query sequence
 
-    :param refpkg_dict: A dictionary of ReferencePackage instances indexed by their prefix values
-    :param output_dir:
-    :param single_query_fasta_files:
-    :param ref_aln_dimensions:
-    :return:
+    :param refpkgs: A dictionary of ReferencePackage instances indexed by their prefix values
+    :param output_dir: Path to a directory for writing the Phylip files
+    :param query_fasta_files: A list containing paths to FASTA files that are to be converted to Phylip format
+    :param ref_aln_dimensions: A dictionary of refpkg.prefix keys mapping to a tuple of the nrow, ncol for a MSA
+    :return: None
     """
 
     # Convert the reference sequence alignments to .phy files for every marker identified
-    for query_fasta in single_query_fasta_files:
+    for query_fasta in query_fasta_files:
         marker = re.match("(.*)_hmm_purified.*", os.path.basename(query_fasta)).group(1)
-        refpkg = refpkg_dict[marker]  # type: ReferencePackage
+        refpkg = refpkgs[marker]  # type: ReferencePackage
 
         ref_alignment_phy = output_dir + marker + ".phy"
         if os.path.isfile(ref_alignment_phy):

--- a/treesapp/classy.py
+++ b/treesapp/classy.py
@@ -952,8 +952,8 @@ class TaxonTest:
         self.classifier_output = ""
 
     def get_optimal_assignment(self):
-        if self.lineage.split('; ')[0] != "Root":
-            self.lineage = "; ".join(["Root"] + self.lineage.split("; "))
+        if self.lineage.split('; ')[0] != "r__Root":
+            self.lineage = "; ".join(["r__Root"] + self.lineage.split("; "))
         return optimal_taxonomic_assignment(self.taxonomic_tree, self.lineage)
 
     def summarise_taxon_test(self):

--- a/treesapp/commands.py
+++ b/treesapp/commands.py
@@ -473,9 +473,8 @@ def create(sys_args):
         # Remove the sequences failing 'filter' and/or only retain the sequences in 'screen'
         fasta_records = create_refpkg.screen_filter_taxa(fasta_records, args.screen, args.filter, ref_seqs.amendments)
         # Remove the sequence records with low resolution lineages, according to args.min_taxonomic_rank
-        # TODO: Replace this function with one offered by TaxonomicHierarchy
-        fasta_records = create_refpkg.remove_by_truncated_lineages(fasta_records,
-                                                                   args.min_taxonomic_rank, ref_seqs.amendments)
+        fasta_records = create_refpkg.remove_by_truncated_lineages(fasta_records, args.min_taxonomic_rank,
+                                                                   ts_create.ref_pkg.taxa_trie, ref_seqs.amendments)
 
         if len(fasta_records.keys()) < 2:
             logging.error("{} sequences post-homology + taxonomy filtering\n".format(len(fasta_records)))

--- a/treesapp/commands.py
+++ b/treesapp/commands.py
@@ -213,6 +213,9 @@ def train(sys_args):
             ts_trainer.hmm_purified_seqs = ts_trainer.input_sequences
             train_seqs.file = ts_trainer.hmm_purified_seqs
             train_seqs.fasta_dict = fasta.read_fasta_to_dict(train_seqs.file)
+            if not train_seqs.fasta_dict:
+                logging.error("No sequences were detected in the HMM-purified FASTA '{}'.\n".format(train_seqs.file))
+                sys.exit(13)
         else:
             train_seqs.file = ts_trainer.hmm_purified_seqs
             train_seqs.load_fasta()

--- a/treesapp/entrez_utils.py
+++ b/treesapp/entrez_utils.py
@@ -1192,6 +1192,11 @@ def read_seq_taxa_table(seq_names_to_taxa: str) -> dict:
     header_names = ["Organism", "Lineage", "Domain", "Phylum", "Class", "Order", "Family", "Genus", "Species"]
     fields = next(tbl_reader)
     field_positions = get_list_positions(fields, header_names)
+    if not field_positions:
+        logging.error("Unable to read headers from sequence-taxa table file {}."
+                      " The table must have some combination of the following column names:\n{}\n"
+                      "".format(seq_names_to_taxa, ','.join(header_names)))
+        sys.exit(3)
 
     try:
         for row in tbl_reader:

--- a/treesapp/fasta.py
+++ b/treesapp/fasta.py
@@ -209,12 +209,13 @@ def read_fasta_to_dict(fasta_file: str) -> dict:
     fasta_dict = dict()
 
     if not os.path.exists(fasta_file):
-        logging.error("'{}' fasta file doesn't exist.\n".format(fasta_file))
+        logging.debug("'{}' fasta file doesn't exist.\n".format(fasta_file))
+        return fasta_dict
 
     try:
         py_fa = Fasta(fasta_file, build_index=False, full_name=True)
     except RuntimeError as error:
-        logging.warning(str(error))
+        logging.debug(str(error)+"\n")
         return fasta_dict
 
     for name, seq in py_fa:  # type: (str, str)
@@ -1253,7 +1254,7 @@ def split_combined_ref_query_fasta(combined_msa, query_msa_file, ref_msa_file) -
     return
 
 
-def multiple_alignment_dimensions(mfa_file, seq_dict=None):
+def multiple_alignment_dimensions(mfa_file: str, seq_dict=None) -> (int, int):
     """
     Checks to ensure all sequences are the same length and returns a tuple of (nrow, ncolumn)
 

--- a/treesapp/lca_calculations.py
+++ b/treesapp/lca_calculations.py
@@ -54,7 +54,7 @@ def optimal_taxonomic_assignment(trie: StringTrie, query_taxon: str):
     while not trie.__contains__(query_taxon) and len(query_taxon.split('; ')) > 1:
         query_taxon = "; ".join(query_taxon.split('; ')[:-1])
     if not trie.__contains__(query_taxon):
-        query_taxon = "Root"
+        query_taxon = "r__Root"
     return query_taxon
 
 

--- a/treesapp/phylo_seq.py
+++ b/treesapp/phylo_seq.py
@@ -304,7 +304,7 @@ class PQuery:
         :return: String representing 'confident' taxonomic assignment for the sequence
         """
         # Sequence likely isn't a FP but is highly divergent from reference set
-        confident_assignment = "Root"
+        confident_assignment = "r__Root"
         if depth < 1:
             return confident_assignment
 

--- a/treesapp/placement_trainer.py
+++ b/treesapp/placement_trainer.py
@@ -493,6 +493,15 @@ def gen_cladex_data(fasta_input: str, executables: dict, ref_pkg: ReferencePacka
     ref_pkg.load_taxonomic_hierarchy()
     for ref_seq in ref_pkg.generate_tree_leaf_references_from_refpkg():
         leaf_taxa_map[ref_seq.number] = ref_seq.lineage
+
+    # Fix the taxonomic lineages of the query sequences in accession_lineage_map
+    for seq_id, lineage in accession_lineage_map.items():
+        taxon_name = lineage.split(ref_pkg.taxa_trie.lin_sep)[-1]
+        if ref_pkg.taxa_trie.emit(taxon_name):
+            accession_lineage_map[seq_id] = ref_pkg.taxa_trie.emit(taxon_name, with_prefix=True)
+        else:
+            pass
+
     # Load the query FASTA and unalign the sequences, in case the fasta is a MSA
     test_seqs = fasta.FASTA(fasta_input)
     test_seqs.load_fasta()

--- a/treesapp/refpkg.py
+++ b/treesapp/refpkg.py
@@ -753,6 +753,10 @@ class ReferencePackage:
 
         # fasta
         ref_fasta_dict = read_fasta_to_dict(self.f__msa)
+        if len(ref_fasta_dict) == 0:
+            logging.error("No sequences were read from Reference Package {}'s FASTA '{}'.\n"
+                          "".format(self.prefix, self.f__msa))
+            sys.exit(13)
         off_target_ref_headers = [ref_num + '_' + self.prefix for ref_num in self.lineage_ids]
         if len(off_target_ref_headers) == 0:
             logging.error("No reference sequences were retained for building testing " + target_clade + "\n")

--- a/treesapp/taxonomic_hierarchy.py
+++ b/treesapp/taxonomic_hierarchy.py
@@ -137,6 +137,7 @@ class TaxonomicHierarchy:
         self.rank_prefix_map = {self.no_rank_name[0]: {self.no_rank_name},  # Tracks prefixes representing ranks
                                 'r': {"root"}}
         # The following are used for tracking the state of the instance's data structures
+        self.rooted = False
         self.trie_key_prefix = True  # Keeps track of the trie's prefix for automated updates
         self.trie_value_prefix = False  # Keeps track of the trie's prefix for automated updates
         self.clean_trie = True  # To track whether taxa of "no rank" are included in the trie
@@ -204,6 +205,30 @@ class TaxonomicHierarchy:
             logging.debug("Taxon name '{}' not present in taxonomic hierarchy.\n".format(prefix_taxon))
             return
 
+    def get_bare_taxon(self, taxon_name: str):
+        """
+        A function for querying the hierarchy with a taxon that lacks a rank-prefix.
+
+        :param taxon_name: A string of a taxon that should be in TaxonomicHierarchy.hierarchy such as 'Bacteria'.
+        :return: Either a Taxon instance whose 'name' attribute matches taxon_name, or None
+        """
+        matches = []
+        if self.canonical_prefix.search(taxon_name):
+            self.so_long_and_thanks_for_all_the_fish("Taxon name ({}) has rank prefix. The function you want is "
+                                                     "TaxonomicHierarchy.get_taxon().\n".format(taxon_name))
+        for p_name, taxon in self.hierarchy.items():  # type: (str, Taxon)
+            if taxon.name == taxon_name:
+                matches.append(taxon)
+
+        if len(matches) == 1:
+            return matches.pop()
+        elif len(matches) > 1:
+            logging.warning("Multiple taxa in taxonomic hierarchy have the name '{}'.\n".format(taxon_name))
+            return
+        else:
+            logging.error("Unable to find taxon name '{}' in taxonomic hierarchy.\n".format(taxon_name))
+            sys.exit(3)
+
     def resolved_as(self, lineage, rank_name="species") -> bool:
         """
         This determines whether a lineage is resolved to at least the rank provided,
@@ -260,18 +285,35 @@ class TaxonomicHierarchy:
             self.hierarchy[root_taxon.prefix_taxon()] = root_taxon
             return root_taxon
 
-    def root_domains(self, root: Taxon) -> None:
-        if root.prefix_taxon() not in self.hierarchy:
-            self.digest_taxon(taxon=root.name, previous=None, rank=root.rank, rank_prefix='r')
+    def root_domains(self, root: Taxon, replace=True) -> Taxon:
+        """
+        Whether lineages are downloaded from a reference database or provided by the user, they tend to not include a
+        taxon that serves as the root, or LUCA, in a taxonomic hierarchy. However, this is essential for some of the
+        taxonomic hierarchy operations that TreeSAPP executes.
+
+        This function ensures that all domains in self.hierarchy have a parent that is the root Taxon instance.
+
+        :param root: A taxon that can be used
+        :param replace: Whether the Taxon currently occupying the root of the hierarchy should be replaced with the new Taxon
+        :return: The Taxon occupying the root rank in the hierarchy
+        """
         if not isinstance(root, Taxon):
             logging.error("Root taxon must be of type taxonomic_hierarchy.Taxon, not {}.\n".format(type(root)))
             raise TypeError
+        if root.prefix_taxon() in self.hierarchy:
+            if replace:
+                self.redirect_hierarchy_paths(old=self.get_taxon(root.prefix_taxon()), rep=root)
+            else:
+                root = self.get_taxon(root.prefix_taxon())
+        else:
+            self.digest_taxon(taxon=root.name, previous=None, rank=root.rank, rank_prefix='r')
         for domain_name in self.rank_representatives("domain", with_prefix=True):
             domain_taxon = self.get_taxon(domain_name)
             if domain_taxon.parent is None:
                 domain_taxon.parent = root
         self.build_multifurcating_trie()
-        return
+        self.rooted = True
+        return root
 
     def reroot_lineage(self, lineage: str) -> str:
         """
@@ -746,6 +788,8 @@ class TaxonomicHierarchy:
 
     def get_prefixed_lineage_from_bare(self, bare_lineage: str) -> str:
         """
+        When given a lineage that lacks rank-prefixes, this function aims to fill them in.
+        NOTE: all taxa with no rank (e.g. cellular organisms, Terrabacteria group) will be removed.
 
         :param bare_lineage: A lineage lacking rank prefixes e.g. "Bacteria; Actinobacteria; Actinobacteria"
         :return: Empty string if lineage or a prefix of the full lineage isn't found, or a lineage with the correct
@@ -759,9 +803,24 @@ class TaxonomicHierarchy:
         lineage_split = bare_lineage.split(self.lin_sep)
         if self.clean_trie:
             lineage_split = self.rm_bad_taxa_from_lineage(lineage_split)  # Not guided by rank prefix
-            lineage_split = self.rm_absent_taxa_from_lineage(lineage_split)  # Not guided by rank prefix
+            self.rm_absent_taxa_from_lineage(lineage_split)  # Not guided by rank prefix
+        if not lineage_split:
+            logging.error("Unable to find a trace of the cleaned lineage '{}' (from {}) in the taxonomic hierarchy.\n"
+                          "".format(self.lin_sep.join(lineage_split), bare_lineage))
+            sys.exit(15)
 
         ref_lineage = ""
+        # While the first positions of the lineage are not in self.trie, prepend the root
+        if not self.query_trie(lineage_split[0]):
+            for prefix in self.trie:
+                if self.query_trie(prefix + self.lin_sep + lineage_split[0]):
+                    lineage_split = prefix.split(self.lin_sep) + lineage_split
+                    break
+        if not self.query_trie(lineage_split[0]):
+            logging.error("Unable to root the lineage '{}' (cleaned is {}) in the taxonomic hierarchy.\n"
+                          "".format(bare_lineage, self.lin_sep.join(lineage_split)))
+            sys.exit(17)
+
         # Iteratively climb the taxonomic lineage until a hit is found or there are no further ranks
         while not ref_lineage and lineage_split:
             taxon = self.query_trie(self.lin_sep.join(lineage_split))
@@ -823,22 +882,23 @@ class TaxonomicHierarchy:
             cleaned_lineage = split_lineage
         return cleaned_lineage
 
-    def rm_absent_taxa_from_lineage(self, lineage_list: list) -> list:
+    def rm_absent_taxa_from_lineage(self, lineage_list: list, with_prefix=False) -> None:
         """
         Removes all taxa from the taxonomic lineage that are not present in self.hierarchy.
         This is meant to remove potentially non-canonical ranks from the unprefixed taxonomic lineage.
 
         :param lineage_list: A list representation of the split taxonomic lineage
-        :return: A list of the taxonomic lineage with the taxa that are not present in self.hierarchy removed
+        :param with_prefix: Boolean controlling whether the inputs have a rank_prefix (True) or not (False)
+        :return: None
         """
-        _taxa = self.get_taxon_names()
+        _taxa = self.get_taxon_names(with_prefix=with_prefix)
         i = 0
         while i < len(lineage_list):
             if lineage_list[i] not in _taxa:
                 lineage_list.pop(i)
             else:
                 i += 1
-        return lineage_list
+        return
 
     def prune_branches(self, tree, leaf_taxa_map: dict, rank="Genus"):
         """
@@ -950,7 +1010,6 @@ class TaxonomicHierarchy:
         if self.canonical_prefix.search(organism):
             return organism
         else:
-
             if self.lin_sep.join(lineage) not in self.trie:
                 logging.error("Lineage elements are not present in prefix tree: '{}'.\n".format("; ".join(lineage)))
                 sys.exit(13)
@@ -966,14 +1025,15 @@ class TaxonomicHierarchy:
         Sometimes the NCBI lineage is incomplete or the rank prefixes are out of order.
         This function checks (and fixes) the following things:
         1. Uses organism to add Species to the lineage if it is missing
-        2. Ensure the progression of rank (i.e. from domain to species) is ordered properly
+        2. Adds the root taxon to the taxonomic lineage if it is missing and present in self.hierarchy
+        3. Ensure the progression of rank (i.e. from root to species) is ordered properly
 
         :param lineage: A taxonomic lineage *with prefixed ranks* separated by self.lin_sep
         :param organism: Name of the organism. Parsed from the sequence header (usually at the end in square brackets)
         :param verbosity: 1 prints debugging messages
         :return: A list of elements for each taxonomic rank representing the taxonomic lineage
         """
-        if not self.trie_key_prefix or not self.clean_trie:
+        if not self.trie_key_prefix or not self.clean_trie or len(self.trie) == 0:
             self.clean_trie = True
             logging.debug("Switching multifurcating trie to include rank prefixes.\n")
             self.build_multifurcating_trie(key_prefix=True)
@@ -996,32 +1056,28 @@ class TaxonomicHierarchy:
                                                      " is not in TaxonomicHierarchy.\n".format(organism, lineage))
             raise RuntimeError
 
+        # Ensure the lineage is rooted, and if not, ensure all domains are properly rooted
         taxon_lineage = [t for t in hierarchy_taxon.lineage() if t.rank in self.accepted_ranks_depths]
+        if taxon_lineage[0].rank != "root":
+            self.root_domains(self.find_root_taxon())
+            taxon_lineage = [t for t in hierarchy_taxon.lineage() if t.rank in self.accepted_ranks_depths]
+
         lineage_list = [t.prefix_taxon() for t in taxon_lineage]
 
         # Handle prefix discrepancy between lineage and organism if organism doesn't have rank prefix
         organism = self.match_organism(organism, lineage_list)
-
-        # Ensure the taxon's most resolved rank is canonical
-        try:
-            rank_depth = self.accepted_ranks_depths[hierarchy_taxon.rank]
-        except KeyError:
-            logging.error("'{}' not in list of accepted ranks ({}).\n"
-                          "".format(hierarchy_taxon.rank, ", ".join(self.accepted_ranks_depths.keys())))
-            raise KeyError
-
         # Determine the state of completeness for the taxon's lineage
         if hierarchy_taxon.rank == "species" or self.proper_species_re.match(lineage_list[-1]):
             if verbosity:
                 logging.debug("check_lineage(): Perfect lineage.\n")
-        elif len(lineage_list) == 6 and rank_depth == 6 and self.proper_species_re.match(organism):
+        elif hierarchy_taxon.rank == "genus" and self.proper_species_re.match(organism):
             if not self.canonical_prefix.search(organism):
                 if self.rank_prefix_map['s'] == "species":
                     organism = "s" + self.taxon_sep + organism
                 else:
                     self.so_long_and_thanks_for_all_the_fish("Unexpected rank prefix for species"
                                                              " in TaxonomicHierarchy.rank_prefix_map\n")
-            self.append_to_hierarchy_dict(organism, lineage_list[-1], rank="species", rank_prefix='s')
+            self.append_to_hierarchy_dict(child=organism, parent=lineage_list[-1], rank="species", rank_prefix='s')
             lineage_list.append(organism)
             if verbosity:
                 logging.debug("check_lineage(): Organism name added to complete the lineage.\n")
@@ -1030,7 +1086,7 @@ class TaxonomicHierarchy:
                 logging.debug("check_lineage(): Truncated lineage.\n")
 
         self.validate_rank_prefixes()  # Ensure the rank-prefix map is formatted correctly
-        # Ensure the order and progression of ranks is correct (no domain -> phylum -> species for example)
+        # Ensure the order and progression of ranks is correct (domain -> phylum -> species for example)
         i = 0
         for taxon in taxon_lineage:  # type: Taxon
             if self.rank_prefix_map[taxon.prefix] not in self.accepted_ranks_depths:

--- a/treesapp/taxonomic_hierarchy.py
+++ b/treesapp/taxonomic_hierarchy.py
@@ -1046,15 +1046,15 @@ class TaxonomicHierarchy:
                           "clean_trie = {3}\n".format(lineage, organism, self.trie_key_prefix, self.clean_trie))
 
         lineage = self.clean_lineage_string(lineage, with_prefix=True)
+        lineage_list = lineage.split(self.lin_sep)
+        self.rm_absent_taxa_from_lineage(lineage_list, with_prefix=True)
 
-        if len(lineage) == 0:
-            return ""
-
-        hierarchy_taxon = self.get_taxon(prefix_taxon=lineage.split(self.lin_sep)[-1])
-        if not hierarchy_taxon:
+        if len(lineage_list) == 0:
             self.so_long_and_thanks_for_all_the_fish("Taxon '{}' from lineage '{}'"
                                                      " is not in TaxonomicHierarchy.\n".format(organism, lineage))
             raise RuntimeError
+
+        hierarchy_taxon = self.get_taxon(prefix_taxon=lineage_list[-1])
 
         # Ensure the lineage is rooted, and if not, ensure all domains are properly rooted
         taxon_lineage = [t for t in hierarchy_taxon.lineage() if t.rank in self.accepted_ranks_depths]


### PR DESCRIPTION
These changes include a major refactor mainly to accomodate two new features:  

1.  Implemented accumulated expected likelihood weight (aELW) _a la_ Kozlov, et al. (2016) for taxonomic assignment from phylogenetic placements.
2. All taxonomic lineages of new reference packages will be rooted (i.e. lineage will be prefixed with "r__Root; ").

Nitty gritty:
- Made a new class called 'PhyloPlace' for storing individual placements of a PQuery.
- For the aELW-based taxonomic assignment, an ETE Tree instance is labelled. Prior to labelling and placement, the reference package's tree is checked for multifurcations. Any found are resolved.
- Fixed the handling of empty fasta files. No more redundant warning message and it doesn't quit when trying to parse the empty Pyfastx.Fasta instance.